### PR TITLE
TRY-0003 - Modify adapterMySQL to make history keyword to can be NULL, issue #772

### DIFF
--- a/packages/database/src/mysql/index.js
+++ b/packages/database/src/mysql/index.js
@@ -64,7 +64,7 @@ class MyslAdapter {
             const sql = `CREATE TABLE ${tableName} 
             (id INT AUTO_INCREMENT PRIMARY KEY, 
             ref varchar(255) NOT NULL,
-            keyword varchar(255) NOT NULL,
+            keyword varchar(255) NULL,
             answer longtext NOT NULL,
             refSerialize varchar(255) NOT NULL,
             phone varchar(255) NOT NULL,


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [ ] Mejoras
- [X] Bug
- [ ] Docs / tests

# Descripción

Arreglado el script que crea la tabla history para que permita keyword con valor null para que no falle cuando se trate de guardar por ejemplo un flowDynamic

> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [Twitter](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
