### PR TITLE
feat: add experimentalStoreArgs to BaileysProvider configuration

### DIFF
--- a/packages/provider-baileys/__tests__/baileysProvider.test.ts
+++ b/packages/provider-baileys/__tests__/baileysProvider.test.ts
@@ -103,6 +103,16 @@ describe('#BaileysProvider', () => {
             port: 3000,
             writeMyself: 'none',
             experimentalStore: false,
+            experimentalStoreArgs: {
+                messagesTypesAllowed: [
+                    'pollCreationMessage',
+                    'pollCreationMessageV2',
+                    'pollCreationMessageV3',
+                    'pollUpdateMessage',
+                ],
+                storeContacts: false,
+                storeLabels: false,
+            },
         }
         // Act
         const baileysProvider = new BaileysProvider({})

--- a/packages/provider-baileys/__tests__/baileysProvider.test.ts
+++ b/packages/provider-baileys/__tests__/baileysProvider.test.ts
@@ -110,6 +110,8 @@ describe('#BaileysProvider', () => {
                     'pollCreationMessageV3',
                     'pollUpdateMessage',
                 ],
+                storeMessages: false,
+                storeChats: false,
                 storeContacts: false,
                 storeLabels: false,
             },

--- a/packages/provider-baileys/src/bailey.ts
+++ b/packages/provider-baileys/src/bailey.ts
@@ -59,6 +59,8 @@ class BaileysProvider extends ProviderClass<WASocket> {
                 'pollCreationMessageV3',
                 'pollUpdateMessage',
             ],
+            storeMessages: false,
+            storeChats: false,
             storeContacts: false,
             storeLabels: false,
         },

--- a/packages/provider-baileys/src/bailey.ts
+++ b/packages/provider-baileys/src/bailey.ts
@@ -52,6 +52,16 @@ class BaileysProvider extends ProviderClass<WASocket> {
         timeRelease: 0, //21600000
         writeMyself: 'none',
         experimentalStore: false,
+        experimentalStoreArgs: {
+            messagesTypesAllowed: [
+                'pollCreationMessage',
+                'pollCreationMessageV2',
+                'pollCreationMessageV3',
+                'pollUpdateMessage',
+            ],
+            storeContacts: false,
+            storeLabels: false,
+        },
     }
 
     store?: ReturnType<typeof makeInMemoryStore>
@@ -114,7 +124,10 @@ class BaileysProvider extends ProviderClass<WASocket> {
             if (this.globalVendorArgs.useBaileysStore) {
                 this.store = !this.globalVendorArgs.experimentalStore
                     ? makeInMemoryStore({ logger: loggerBaileys })
-                    : bindStore({ logger: loggerBaileys })
+                    : bindStore({
+                          logger: loggerBaileys,
+                          experimentalStoreArgs: this.globalVendorArgs.experimentalStoreArgs,
+                      })
 
                 if (this.store?.readFromFile) this.store?.readFromFile(`${NAME_DIR_SESSION}/baileys_store.json`)
 

--- a/packages/provider-baileys/src/type.ts
+++ b/packages/provider-baileys/src/type.ts
@@ -10,6 +10,8 @@ export interface BaileyGlobalVendorArgs extends GlobalVendorArgs {
     experimentalStore?: boolean
     experimentalStoreArgs?: {
         messagesTypesAllowed: string[]
+        storeMessages: boolean
+        storeChats: boolean
         storeContacts: boolean
         storeLabels: boolean
     }

--- a/packages/provider-baileys/src/type.ts
+++ b/packages/provider-baileys/src/type.ts
@@ -8,5 +8,10 @@ export interface BaileyGlobalVendorArgs extends GlobalVendorArgs {
     useBaileysStore: boolean
     timeRelease?: number
     experimentalStore?: boolean
+    experimentalStoreArgs?: {
+        messagesTypesAllowed: string[]
+        storeContacts: boolean
+        storeLabels: boolean
+    }
     host?: any
 }


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [ x] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción
Agrego  de manera experimental al store para poder permitir algunos eventos y almanenarlos en store 

```javascript
 experimentalStoreArgs: {
    messagesTypesAllowed: [
        'pollCreationMessage',
        'pollCreationMessageV2',
        'pollCreationMessageV3',
        'pollUpdateMessage',
    ],
    storeMessages: false,
    storeChats: false,
    storeContacts: false,
    storeLabels: false,
},
```

Esto es de manera experimental la idea es poder dejar atras el useBaileysStore desactivado, pero en caso de requerirlo poder contar con los mensajes almacenados de encuesta para poder leer los eventos y usar la funcionalidad de encuestas como menú.

> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
