### PR TITLE
fix(adapter): :bug: incorrect `HistoryEntry` on PostgreSQL Adaptor

### DIFF
--- a/packages/database-postgres/__tests__/ postgresAdapter.test.ts
+++ b/packages/database-postgres/__tests__/ postgresAdapter.test.ts
@@ -13,7 +13,7 @@ const historyMock: HistoryEntry = {
     keyword: 'exampleKeyword',
     answer: 'exampleAnswer',
     refSerialize: 'exampleRefSerialize',
-    phone: '123456789',
+    from: '123456789',
     options: {
         option1: 'value1',
         option2: 42,
@@ -83,7 +83,7 @@ test('getPrevByNumber - getPrevByNumber returns the previous history entry', asy
     }
 
     const result = await postgreSQLAdapter.getPrevByNumber(from)
-    assert.is(result?.phone, historyMock.phone)
+    assert.is(result?.from, historyMock.from)
     assert.is(result?.ref, historyMock.ref)
     assert.is(result?.refSerialize, undefined)
 })

--- a/packages/database-postgres/src/postgresAdapter.ts
+++ b/packages/database-postgres/src/postgresAdapter.ts
@@ -47,7 +47,7 @@ class PostgreSQLAdapter extends MemoryDB {
     }
 
     async save(ctx: HistoryEntry): Promise<void> {
-        const values = [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.phone, JSON.stringify(ctx.options)]
+        const values = [ctx.ref, ctx.keyword, ctx.answer, ctx.refSerialize, ctx.from, JSON.stringify(ctx.options)]
         const query = `SELECT save_or_update_history_and_contact($1, $2, $3, $4, $5, $6)`
 
         try {
@@ -60,7 +60,7 @@ class PostgreSQLAdapter extends MemoryDB {
     }
 
     async getContact(ctx: HistoryEntry): Promise<Contact | undefined> {
-        const from = ctx.phone
+        const from = ctx.from
         const query = `SELECT * FROM public.contact WHERE phone = $1 LIMIT 1`
         try {
             const result = await this.db.query(query, [from])

--- a/packages/database-postgres/src/types.ts
+++ b/packages/database-postgres/src/types.ts
@@ -3,7 +3,7 @@ export type HistoryEntry = {
     keyword?: string
     answer: string
     refSerialize: string
-    phone: string
+    from: string
     options?: Record<string, any>
 }
 


### PR DESCRIPTION
# What type of Pull Request is it?

- [ ] Improvements
- [x ] Bug
- [ ] Docs / tests

#  Description

Issue: Phone number was not saving when using PostgreSQL

Reason: `HistoryEntry.phone` is invalid. The correct property provided from `ctx` is `from`

Change: Updated `HistoryEntry`