### PR TITLE
feat(contributing): :sparkles: addDynamicAction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ nonExistingFilePath
 !.gitignore
 /packages/provider-web-whatsapp/bot.qr.png
 /packages/bot/__mock__/*.opus
+/packages/bot/__mock__/experimental
 /packages/provider-baileys/*_sessions
 /packages/provider-baileys/*.png
 /packages/provider-web-whatsapp/.wwebjs_auth/*
+.qdrant*
+/**/mock*

--- a/packages/bot/__mock__/env.ts
+++ b/packages/bot/__mock__/env.ts
@@ -61,6 +61,7 @@ const parseAnswers = (answers: any[]) => {
             !a.answer.includes('__call_action__') &&
             !a.answer.includes('__goto_flow__') &&
             !a.answer.includes('__end_flow__') &&
+            !a.answer.includes('__dynamic_call_action__') &&
             !a.answer.includes('__capture_only_intended__')
     )
 }

--- a/packages/bot/__tests__/e2e/0.2.3-addDynamicAction.test.ts
+++ b/packages/bot/__tests__/e2e/0.2.3-addDynamicAction.test.ts
@@ -1,0 +1,381 @@
+import { suite } from 'uvu'
+import * as assert from 'uvu/assert'
+
+import { setup, clear, parseAnswers } from '../../__mock__/env'
+import { addKeyword, createBot, createFlow, EVENTS } from '../../src'
+import { delay } from '../../src/utils'
+
+const suiteCase = suite('Flujo: Dynamic callbacks')
+
+suiteCase.before.each(setup)
+suiteCase.after.each(clear)
+
+suiteCase(`Debe saltar del id: dynamic al id: t2_3`, async ({ database, provider }) => {
+    /*
+        Se lanza el primer trigger `soy t2`, luego se captura la respuesta
+
+        # caso de uso: 
+            - El cliente indica algo diferente a la palabra `foo`, esto dispararia el ultimo `addAnswer` con id: t2_3
+
+    */
+
+    const f1 = addKeyword(EVENTS.WELCOME, undefined)
+        .addAnswer('soy t2', { capture: true })
+        .addDynamicAction(
+            async (ctx) => {
+                return new Promise((resolve) => {
+                    const re = /foo/gim
+
+                    resolve(re.test(ctx.body!))
+                })
+            },
+            async (ctx, { flowDynamic }) => await flowDynamic('soy dynamic'),
+            { id: 'dynamic', skip_id: 't2_3' }
+        )
+        .addAnswer('soy t2_2', { id: 't2_2' })
+        .addAnswer('soy t2_3', { id: 't2_3' })
+
+    await createBot({
+        database,
+        flow: createFlow([f1]),
+        provider,
+    })
+
+    await provider.delaySendMessage(100, 'message', {
+        from: '000',
+        body: 'hola',
+    })
+    await delay(250)
+
+    await provider.delaySendMessage(100, 'message', {
+        from: '000',
+        body: 'aja',
+    })
+    await delay(250)
+
+    const history = parseAnswers(database.listHistory).map((item) => item.answer)
+
+    assert.is('soy t2_3', history.at(-1))
+})
+
+suiteCase(`Debe terminar en el 'endFlow'`, async ({ database, provider }) => {
+    /*
+        Se lanza el primer trigger `soy t2`, luego se captura la respuesta
+
+        # caso de uso: 
+            - El cliente indica la palabra `t2`, esto daria por terminado el flujo.
+
+    */
+
+    const t2 = addKeyword(EVENTS.WELCOME, undefined)
+        .addAnswer('soy t2')
+        .addAction({ id: 't2_0', capture: true }, async (ctx, { endFlow }) => {
+            if (ctx.body === 't2') return await endFlow()
+        })
+        .addDynamicAction(
+            async (ctx) => {
+                return new Promise((resolve) => {
+                    const re = /foo/gim
+
+                    resolve(re.test(ctx.body!))
+                })
+            },
+            async (ctx, { flowDynamic }) => await flowDynamic('soy dynamic'),
+            { id: 'dynamic', skip_id: 't2_3' }
+        )
+        .addAnswer('soy t2_2', { id: 't2_2' })
+        .addAnswer('soy t2_3', { id: 't2_3' })
+
+    await createBot({
+        database,
+        flow: createFlow([t2]),
+        provider,
+    })
+
+    await provider.delaySendMessage(100, 'message', {
+        from: '000',
+        body: 'hola',
+    })
+    await delay(250)
+
+    await provider.delaySendMessage(100, 'message', {
+        from: '000',
+        body: 't2',
+    })
+    await delay(250)
+
+    await provider.delaySendMessage(100, 'message', {
+        from: '000',
+        body: 'aja',
+    })
+    await delay(250)
+
+    const history = parseAnswers(database.listHistory).map((item) => item.answer)
+
+    assert.is('t2', history.at(1))
+    assert.is(4, history.length)
+    assert.is('soy t2', history.at(-1))
+})
+
+suiteCase(`Debe completar todo el flow`, async ({ database, provider }) => {
+    /*
+        Se lanza el primer trigger `soy t2`, luego se captura la respuesta
+
+        # caso de uso: 
+            - El cliente indica la palabra `foo`, esto completaria todo el flujo.
+
+    */
+
+    const t2 = addKeyword(EVENTS.WELCOME, undefined)
+        .addAnswer('soy t2', { capture: true })
+        .addDynamicAction(
+            async (ctx) => {
+                return new Promise((resolve) => {
+                    const re = /foo/gim
+
+                    resolve(re.test(ctx.body!))
+                })
+            },
+            async (ctx, { flowDynamic }) => await flowDynamic('soy dynamic'),
+            { id: 'dynamic', skip_id: 't2_3' }
+        )
+        .addAnswer('soy t2_2', { id: 't2_2' })
+        .addAnswer('soy t2_3', { id: 't2_3' })
+
+    await createBot({
+        database,
+        flow: createFlow([t2]),
+        provider,
+    })
+
+    await provider.delaySendMessage(100, 'message', {
+        from: '000',
+        body: 'hola',
+    })
+    await delay(250)
+
+    await provider.delaySendMessage(100, 'message', {
+        from: '000',
+        body: 'foo',
+    })
+    await delay(250)
+
+    const history = parseAnswers(database.listHistory).map((item) => item.answer)
+
+    assert.is(5, history.length)
+})
+
+suiteCase(
+    `Multiples 'addDynamicAction', salta el primero y ejecuta el segundo dynamic`,
+    async ({ database, provider }) => {
+        /*
+        Se lanza el primer trigger `soy t2`, luego se captura la respuesta
+
+        # caso de uso: 
+            - El sistema deberá poder saltar el primero dynamic y ejecutar el segundo, (Respetando las condiciones)
+
+    */
+
+        const f1 = addKeyword(EVENTS.WELCOME, undefined)
+            .addAnswer('soy t2', { capture: true })
+            .addDynamicAction(
+                async (ctx) => {
+                    return new Promise((resolve) => {
+                        const re = /foo/gim
+
+                        resolve(re.test(ctx.body!))
+                    })
+                },
+                async (ctx, { flowDynamic }) => await flowDynamic('soy dynamic'),
+                { id: 'dynamic', skip_id: 't2_3' }
+            )
+            .addAnswer('soy t2_2', { id: 't2_2' })
+            .addAnswer('soy t2_3', { id: 't2_3', capture: true })
+            .addDynamicAction(
+                async (ctx) => {
+                    return new Promise((resolve) => {
+                        const re = /foo2/gim
+
+                        resolve(re.test(ctx.body!))
+                    })
+                },
+                async (ctx, { flowDynamic }) => await flowDynamic('soy dynamic2'),
+                { id: 'dynamic2' }
+            )
+            .addAnswer('soy t2_4', { id: 't2_4' })
+            .addAnswer('soy t2_5', { id: 't2_5' })
+
+        await createBot({
+            database,
+            flow: createFlow([f1]),
+            provider,
+        })
+
+        await provider.delaySendMessage(100, 'message', {
+            from: '000',
+            body: 'hola',
+        })
+        await delay(250)
+
+        await provider.delaySendMessage(100, 'message', {
+            from: '000',
+            body: 'aja',
+        })
+        await delay(250)
+
+        await provider.delaySendMessage(100, 'message', {
+            from: '000',
+            body: 'foo2',
+        })
+        await delay(250)
+
+        const history = parseAnswers(database.listHistory).map((item) => item.answer)
+
+        assert.equal(true, !history.includes('soy dynamic'))
+        assert.equal(true, !history.includes('soy t2_2'))
+        assert.is(7, history.length)
+    }
+)
+
+suiteCase(`Multiples 'addDynamicAction'`, async ({ database, provider }) => {
+    /*
+        Se lanza el primer trigger `soy t2`, luego se captura la respuesta
+
+        # caso de uso: 
+            - Se ejecutan todos los addDynamicActions
+
+    */
+
+    const f1 = addKeyword(EVENTS.WELCOME, undefined)
+        .addAnswer('soy t2', { capture: true })
+        .addDynamicAction(
+            async (ctx) => {
+                return new Promise((resolve) => {
+                    const re = /foo/gim
+
+                    resolve(re.test(ctx.body!))
+                })
+            },
+            async (ctx, { flowDynamic }) => await flowDynamic('soy dynamic'),
+            { id: 'dynamic', skip_id: 't2_3' }
+        )
+        .addAnswer('soy t2_2', { id: 't2_2' })
+        .addAnswer('soy t2_3', { id: 't2_3', capture: true })
+        .addDynamicAction(
+            async (ctx) => {
+                return new Promise((resolve) => {
+                    const re = /foo2/gim
+
+                    resolve(re.test(ctx.body!))
+                })
+            },
+            async (ctx, { flowDynamic }) => await flowDynamic('soy dynamic2'),
+            { id: 'dynamic2' }
+        )
+        .addAnswer('soy t2_4', { id: 't2_4' })
+        .addAnswer('soy t2_5', { id: 't2_5' })
+
+    await createBot({
+        database,
+        flow: createFlow([f1]),
+        provider,
+    })
+
+    await provider.delaySendMessage(100, 'message', {
+        from: '000',
+        body: 'hola',
+    })
+    await delay(250)
+
+    await provider.delaySendMessage(100, 'message', {
+        from: '000',
+        body: 'foo',
+    })
+    await delay(250)
+
+    await provider.delaySendMessage(100, 'message', {
+        from: '000',
+        body: 'foo2',
+    })
+    await delay(250)
+
+    const history = parseAnswers(database.listHistory).map((item) => item.answer)
+
+    assert.equal(true, history.includes('soy dynamic'))
+    assert.equal(true, history.includes('soy dynamic2'))
+    assert.is(9, history.length)
+})
+
+suiteCase(
+    `Multiples 'addDynamicAction', el ultimo 'addDynamicAction' no se ejecuta`,
+    async ({ database, provider }) => {
+        /*
+        Se lanza el primer trigger `soy t2`, luego se captura la respuesta
+
+        # caso de uso: 
+            - Se ejecutan solo el primer addDynamicAction
+
+    */
+
+        const f1 = addKeyword(EVENTS.WELCOME, undefined)
+            .addAnswer('soy t2', { capture: true })
+            .addDynamicAction(
+                async (ctx) => {
+                    return new Promise((resolve) => {
+                        const re = /foo/gim
+
+                        resolve(re.test(ctx.body!))
+                    })
+                },
+                async (ctx, { flowDynamic }) => await flowDynamic('soy dynamic'),
+                { id: 'dynamic', skip_id: 't2_3' }
+            )
+            .addAnswer('soy t2_2', { id: 't2_2' })
+            .addAnswer('soy t2_3', { id: 't2_3', capture: true })
+            .addDynamicAction(
+                async (ctx) => {
+                    return new Promise((resolve) => {
+                        const re = /foo2/gim
+
+                        resolve(re.test(ctx.body!))
+                    })
+                },
+                async (ctx, { flowDynamic }) => await flowDynamic('soy dynamic2'),
+                { id: 'dynamic2' }
+            )
+            .addAnswer('soy t2_4', { id: 't2_4' })
+            .addAnswer('soy t2_5', { id: 't2_5' })
+
+        await createBot({
+            database,
+            flow: createFlow([f1]),
+            provider,
+        })
+
+        await provider.delaySendMessage(100, 'message', {
+            from: '000',
+            body: 'hola',
+        })
+        await delay(250)
+
+        await provider.delaySendMessage(100, 'message', {
+            from: '000',
+            body: 'foo',
+        })
+        await delay(250)
+
+        await provider.delaySendMessage(100, 'message', {
+            from: '000',
+            body: 'eje',
+        })
+        await delay(250)
+
+        const history = parseAnswers(database.listHistory).map((item) => item.answer)
+
+        assert.equal(true, history.includes('soy dynamic'))
+        assert.equal(true, !history.includes('soy dynamic2'))
+        assert.is(8, history.length)
+    }
+)
+
+suiteCase.run()

--- a/packages/bot/__tests__/units/flowClass.test.ts
+++ b/packages/bot/__tests__/units/flowClass.test.ts
@@ -10,19 +10,19 @@ test('[FlowClass] Probando instanciamiento de clase', () => {
     assert.instance(flowClass, FlowClass)
 })
 
-test('[FlowClass] Probando find', () => {
+test('[FlowClass] Probando find', async () => {
     const MOCK_FLOW = addKeyword('hola').addAnswer('Buenas!')
     const flowClass = new FlowClass([MOCK_FLOW])
-    const result = flowClass.find('hola')
+    const result = await flowClass.find('hola')
     assert.equal(result[0].answer, 'Buenas!')
 })
 
-test('[FlowClass] Probando findBySerialize', () => {
+test('[FlowClass] Probando findBySerialize', async () => {
     const MOCK_FLOW = addKeyword('hola').addAnswer('Buenas!')
     const flowClass = new FlowClass([MOCK_FLOW])
-    const result = flowClass.find('hola')
-    const resultSerialize = flowClass.findBySerialize(result[0].refSerialize)
-    assert.equal(resultSerialize.answer, 'Buenas!')
+    const result = await flowClass.find('hola')
+    const resultSerialize = flowClass.findBySerialize(result[0].refSerialize!)
+    assert.equal(resultSerialize?.answer, 'Buenas!')
 })
 
 test('[FlowClass] Probando findIndexByRef', () => {
@@ -38,7 +38,7 @@ test('[FlowClass] Probando findSerializeByRef', () => {
     const flowClass = new FlowClass([MOCK_FLOW])
     const ref = flowClass.flowSerialize[0].ref
     const context = flowClass.findSerializeByRef(ref)
-    assert.equal(context.keyword, 'hola')
+    assert.equal(context?.keyword, 'hola')
 })
 
 test('[FlowClass] Probando getRefToContinueChild', () => {
@@ -46,7 +46,7 @@ test('[FlowClass] Probando getRefToContinueChild', () => {
     const MOCK_FLOW = addKeyword('hola').addAnswer('Buenas!', { ref: '1000' }, null, [MOCK_FLOW_CHILD])
     const flowClass = new FlowClass([MOCK_FLOW])
     const context = flowClass.getRefToContinueChild('a243678f1e3e31a35c43b03c53503ef7')
-    assert.equal(context.keyword, 'ping')
+    assert.equal(context?.keyword, 'ping')
 })
 
 test('[FlowClass] Probando getFlowsChild', () => {

--- a/packages/bot/src/io/methods/addKeyword.ts
+++ b/packages/bot/src/io/methods/addKeyword.ts
@@ -1,6 +1,13 @@
 import { addAnswer } from './addAnswer'
 import { toJson } from './toJson'
-import type { ActionPropertiesKeyword, CallbackFunction, TContext, TFlow } from '../../types'
+import type {
+    ActionPropertiesGeneric,
+    ActionPropertiesKeyword,
+    CallbackFunction,
+    DynamicCallback,
+    TContext,
+    TFlow,
+} from '../../types'
 import { generateRef } from '../../utils/hash'
 
 /**
@@ -49,6 +56,20 @@ const addKeyword = <P = any, B = any>(
                 return addAnswer(ctx)('__capture_only_intended__', cb, flagCb)
             }
             return addAnswer(ctx)('__call_action__', null, cb)
+        },
+        addDynamicAction: (
+            dynamicCallback: DynamicCallback,
+            cb: CallbackFunction<P, B> = () => null,
+            optionsProps: ActionPropertiesGeneric
+        ) => {
+            return addAnswer(ctx)(
+                '__dynamic_call_action__',
+                {
+                    ...optionsProps,
+                    dynamicCapture: dynamicCallback,
+                },
+                cb
+            )
         },
         toJson: toJson(ctx),
     }

--- a/packages/bot/src/types.ts
+++ b/packages/bot/src/types.ts
@@ -64,7 +64,7 @@ export type ActionPropertiesKeyword = {
     delay?: number
     regex?: boolean
     sensitive?: boolean
-}
+} & TCTXExtendOptions
 
 /**
  * @typedef ActionPropertiesGeneric
@@ -197,6 +197,13 @@ export interface TCTXoptions extends ActionPropertiesKeyword {
     answer?: string
 }
 
+export interface TCTXExtendOptions {
+    dynamicCapture?: (ctx: MessageContextIncoming) => Promise<boolean>
+    id?: string
+    skip_id?: string
+}
+export type DynamicCallback = (ctx: MessageContextIncoming) => Promise<boolean>
+
 /**
  * @typedef Callbacks
  * @type {{ [key: string]: () => void }}
@@ -222,7 +229,7 @@ export interface TContext {
     answer?: string | string[]
     refSerialize?: string
     endFlow?: boolean
-    options: TCTXoptions
+    options: TCTXoptions & TCTXExtendOptions
     callbacks?: Callbacks
     json?: TContext[]
     ctx?: TContext
@@ -248,6 +255,12 @@ export interface TFlow<P = any, B = any> {
     addAction: (
         actionProps: ActionPropertiesGeneric | CallbackFunction<P, B>,
         cb?: CallbackFunction<P, B>,
+        nested?: TFlow<P, B> | TFlow<P, B>[] | null
+    ) => TFlow<P, B>
+    addDynamicAction: (
+        dynamicCallback: DynamicCallback,
+        cb: CallbackFunction<P, B>,
+        optionsProps: ActionPropertiesGeneric,
         nested?: TFlow<P, B> | TFlow<P, B>[] | null
     ) => TFlow<P, B>
     toJson: () => TContext[]


### PR DESCRIPTION
crea  flows dinamicos con validaciones internas

# Que tipo de Pull Request es?

- [X ] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

La nueva acción `addDynamicAction` es una alternativa a la idea de manejar flows de forma dinamicas; esto quiere decir que las validaciónes no van de cara al usuario sino que se ejecuta inmediatamente en el core del sistema.

el archivo: [Tests ejecutados](https://github.com/Elimeleth/experimental_builderbot/blob/elidev/packages/bot/__tests__/e2e/0.2.3-addDynamicAction.test.ts)

explica ciertos casos de usos que pueden ser extendidos aun mas.

![image](https://github.com/user-attachments/assets/f7a6aeae-1345-42a8-8231-5f8bfcdf22ac)
![Screenshot from 2024-09-03 13-16-03](https://github.com/user-attachments/assets/73c77052-8ba1-4cf4-95c1-6093d7090ed8)
![dynamicCallack](https://github.com/user-attachments/assets/9923b400-3111-42a8-81b9-66a6bbf1c3dd)
