### PR TITLE
Update provider.ts adding requestLocation

### DIFF
--- a/packages/provider-meta/src/meta/provider.ts
+++ b/packages/provider-meta/src/meta/provider.ts
@@ -128,6 +128,15 @@ class MetaProvider extends ProviderClass<MetaInterface> implements MetaInterface
             return 'ERROR'
         }
     }
+    saveBuffer = async (ctx: Partial<Message & BotContext>, options: SaveFileOptions = {}): Promise<string> => {
+        try {
+            const { buffer } = await downloadFile(ctx?.url, this.globalVendorArgs.jwtToken)
+            return buffer
+        } catch (err) {
+            console.log(`[Error]:`, err.message)
+            return 'ERROR'
+        }
+    }
 
     busEvents = () => [
         {
@@ -616,6 +625,26 @@ class MetaProvider extends ProviderClass<MetaInterface> implements MetaInterface
             },
         }
         return this.sendMessageMeta(body)
+    }
+
+    requestLocation =async (to, bodyText) => {
+        to = parseMetaNumber(to);
+        const body = {
+            messaging_product: 'whatsapp',
+            recipient_type: 'individual',
+            to,
+            type: 'interactive',
+            interactive: {
+                type: 'location_request_message',
+                body: {
+                    text: bodyText,
+                },
+                action: {
+                    name: 'send_location',
+                },
+            },
+        }
+        return this.sendMessageMeta(body);
     }
 
     sendLocation = async (to: string, localization: Localization) => {


### PR DESCRIPTION
Adding requestLocation to request the user to send their location

# Que tipo de Pull Request es?

- [x] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

Request Location
Se añade requestLocation, este método permite solicitar al usuario que interactua con el bot que envie su ubicación.
![image](https://github.com/user-attachments/assets/7684d1fb-0635-425a-bc17-946d1c8850dc)

Save Buffer
Se añade saveBuffer al provider para obtener directamente el buffer de una nota de voz, imagen o video para que pueda ser enviado directamente a un modelo de IA.

Caso de uso: 

1. Enviar el buffer de una nota de voz directamente a Whisper de OpenAI para transcribirla y poderla pasar a gpt-4o-mini como pregunta para obtener una respuesta en base a la transcripción.
2. Enviar el bufffer de una imagen a GPT-Vision para interpretarla y responder.
3. Cualquier caso donde se necesite el buffer para interacturar con los datos.
