### PR TITLE
Update number.ts

### DIFF
--- a/packages/provider-meta/src/utils/number.ts
+++ b/packages/provider-meta/src/utils/number.ts
@@ -1,4 +1,7 @@
 export const parseMetaNumber = (number: string): string => {
-    number = number.replace(/\+/g, '').replace(/\s/g, '')
-    return number
+    if (typeof number !== 'string') {
+        return number;
+    }
+    number = number.replace(/\+/g, '').replace(/\s/g, '');
+    return number;
 }


### PR DESCRIPTION
Fixing bug on parseMetaNumber when input it's not a string

# Que tipo de Pull Request es?

- [ ] Mejoras
- [x] Bug
- [ ] Docs / tests

# Descripción

Cuando el input de parseMetaNumber no hace match con el regex falla, se cambia para comprobar antes de intentar reemplazar y asi no hace crash el bot


> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
