### PR TITLE
Add optional silent mode for printer logs without affecting global behavior

### DIFF
--- a/.hintrc
+++ b/.hintrc
@@ -1,0 +1,14 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "axe/structure": [
+      "default",
+      {
+        "list": "off",
+        "listitem": "off"
+      }
+    ]
+  }
+}

--- a/packages/bot/src/utils/interactive.ts
+++ b/packages/bot/src/utils/interactive.ts
@@ -2,8 +2,6 @@ import color from 'picocolors'
 
 type PrinterFunction = (message: string | string[], title: string, cName?: 'bgMagenta' | 'bgRed' | 'bgCyan') => void
 
-const NODE_ENV: string = process.env.NODE_ENV || 'dev'
-
 /**
  *
  * @param message
@@ -11,12 +9,17 @@ const NODE_ENV: string = process.env.NODE_ENV || 'dev'
  * @param cName
  */
 const printer: PrinterFunction = (message, title, cName) => {
-    if (NODE_ENV !== 'test') {
-        cName = cName ?? 'bgRed'
-        if (title.length) console.log(color[cName](`${title}`))
-        console.log(color.yellow(Array.isArray(message) ? message.join('\n') : message))
-        console.log(``)
-    }
+    const NODE_ENV: string = process.env.NODE_ENV || 'dev'
+
+    const SILENT: string = process.env.BUILDERBOT_SILENT || 'false'
+
+    // 👉 Solo imprime si no está silenciado y no estás en test
+    if (SILENT === 'true' || NODE_ENV === 'test') return
+
+    cName = cName ?? 'bgRed'
+    if (title.length) console.log(color[cName](`${title}`))
+    console.log(color.yellow(Array.isArray(message) ? message.join('\n') : message))
+    console.log(``)
 }
 
 export { printer }


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [X] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

Este PR introduce una mejora opcional en la función printer() del core de Builderbot, permitiendo silenciar los logs de consola sin alterar el comportamiento existente para otros desarrolladores o entornos.

🔍 Detalles del cambio:

Se añade soporte para la variable de entorno BUILDERBOT_SILENT.

Cuando BUILDERBOT_SILENT=true, se desactiva la impresión de logs del printer().

Mantiene el comportamiento actual por defecto (sin cambios para los demás).

Compatible con cualquier entorno (development, production, test).
