### PR TITLE
feat(provider-telegram): add sendPresenceUpdate method for typing indicator

### DIFF
--- a/packages/provider-telegram/__tests__/telegram.provider.test.ts
+++ b/packages/provider-telegram/__tests__/telegram.provider.test.ts
@@ -46,10 +46,16 @@ jest.mock('telegram', () => ({
         markAsRead: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
         downloadMedia: jest.fn<() => Promise<Buffer>>().mockResolvedValue(Buffer.from('media-data')),
         addEventHandler: jest.fn(),
+        invoke: jest.fn<() => Promise<void>>().mockResolvedValue(undefined),
         session: { save: jest.fn().mockReturnValue('session-string') },
     })),
     Api: {
         User: jest.fn(),
+        SendMessageTypingAction: jest.fn().mockImplementation(() => ({ className: 'SendMessageTypingAction' })),
+        SendMessageCancelAction: jest.fn().mockImplementation(() => ({ className: 'SendMessageCancelAction' })),
+        messages: {
+            SetTyping: jest.fn().mockImplementation((args) => ({ ...args, className: 'SetTyping' })),
+        },
     },
 }))
 
@@ -376,6 +382,43 @@ describe('#TelegramProvider', () => {
         test('should delegate to client.markAsRead', async () => {
             await provider.markAsRead('user123')
             expect(provider.client.markAsRead).toHaveBeenCalledWith('user123')
+        })
+    })
+
+    // ===== sendPresenceUpdate =====
+
+    describe('#sendPresenceUpdate', () => {
+        test('should send typing action by default', async () => {
+            const { Api } = require('telegram')
+
+            await provider.sendPresenceUpdate('user123')
+
+            expect(Api.SendMessageTypingAction).toHaveBeenCalled()
+            expect(Api.messages.SetTyping).toHaveBeenCalledWith(
+                expect.objectContaining({ peer: 'user123' })
+            )
+            expect(provider.client.invoke).toHaveBeenCalled()
+        })
+
+        test('should send typing action when action is "typing"', async () => {
+            const { Api } = require('telegram')
+
+            await provider.sendPresenceUpdate('user123', 'typing')
+
+            expect(Api.SendMessageTypingAction).toHaveBeenCalled()
+            expect(provider.client.invoke).toHaveBeenCalled()
+        })
+
+        test('should send cancel action when action is "cancel"', async () => {
+            const { Api } = require('telegram')
+
+            await provider.sendPresenceUpdate('user123', 'cancel')
+
+            expect(Api.SendMessageCancelAction).toHaveBeenCalled()
+            expect(Api.messages.SetTyping).toHaveBeenCalledWith(
+                expect.objectContaining({ peer: 'user123' })
+            )
+            expect(provider.client.invoke).toHaveBeenCalled()
         })
     })
 

--- a/packages/provider-telegram/__tests__/telegram.provider.test.ts
+++ b/packages/provider-telegram/__tests__/telegram.provider.test.ts
@@ -52,6 +52,7 @@ jest.mock('telegram', () => ({
     Api: {
         User: jest.fn(),
         SendMessageTypingAction: jest.fn().mockImplementation(() => ({ className: 'SendMessageTypingAction' })),
+        SendMessageRecordAudioAction: jest.fn().mockImplementation(() => ({ className: 'SendMessageRecordAudioAction' })),
         SendMessageCancelAction: jest.fn().mockImplementation(() => ({ className: 'SendMessageCancelAction' })),
         messages: {
             SetTyping: jest.fn().mockImplementation((args) => ({ ...args, className: 'SetTyping' })),
@@ -415,6 +416,18 @@ describe('#TelegramProvider', () => {
             await provider.sendPresenceUpdate('user123', 'cancel')
 
             expect(Api.SendMessageCancelAction).toHaveBeenCalled()
+            expect(Api.messages.SetTyping).toHaveBeenCalledWith(
+                expect.objectContaining({ peer: 'user123' })
+            )
+            expect(provider.client.invoke).toHaveBeenCalled()
+        })
+
+        test('should send recording action when action is "recording"', async () => {
+            const { Api } = require('telegram')
+
+            await provider.sendPresenceUpdate('user123', 'recording')
+
+            expect(Api.SendMessageRecordAudioAction).toHaveBeenCalled()
             expect(Api.messages.SetTyping).toHaveBeenCalledWith(
                 expect.objectContaining({ peer: 'user123' })
             )

--- a/packages/provider-telegram/src/telegram.provider.ts
+++ b/packages/provider-telegram/src/telegram.provider.ts
@@ -122,6 +122,28 @@ class TelegramProvider extends ProviderClass<TelegramEvents> {
         await this.client.markAsRead(from)
     }
 
+    /**
+     * Send a typing indicator to a chat
+     * @param chatId - The chat/user ID to send the typing indicator to
+     * @param action - 'typing' to show typing indicator, 'cancel' to hide it (default: 'typing')
+     * @example
+     * // Show typing indicator
+     * await provider.sendPresenceUpdate('user123')
+     *
+     * // Hide typing indicator
+     * await provider.sendPresenceUpdate('user123', 'cancel')
+     */
+    async sendPresenceUpdate(chatId: EntityLike, action: 'typing' | 'cancel' = 'typing'): Promise<void> {
+        const typingAction =
+            action === 'typing' ? new Api.SendMessageTypingAction() : new Api.SendMessageCancelAction()
+        await this.client.invoke(
+            new Api.messages.SetTyping({
+                peer: chatId,
+                action: typingAction,
+            })
+        )
+    }
+
     async sendButtons<K = any>(chatId: string, text: string, buttons: any[]): Promise<K> {
         return
     }

--- a/packages/provider-telegram/src/telegram.provider.ts
+++ b/packages/provider-telegram/src/telegram.provider.ts
@@ -123,19 +123,28 @@ class TelegramProvider extends ProviderClass<TelegramEvents> {
     }
 
     /**
-     * Send a typing indicator to a chat
-     * @param chatId - The chat/user ID to send the typing indicator to
-     * @param action - 'typing' to show typing indicator, 'cancel' to hide it (default: 'typing')
+     * Send a presence indicator to a chat
+     * @param chatId - The chat/user ID to send the indicator to
+     * @param action - 'typing' to show typing indicator, 'recording' to show recording indicator, 'cancel' to hide it (default: 'typing')
      * @example
      * // Show typing indicator
      * await provider.sendPresenceUpdate('user123')
      *
-     * // Hide typing indicator
+     * // Show recording indicator
+     * await provider.sendPresenceUpdate('user123', 'recording')
+     *
+     * // Hide indicator
      * await provider.sendPresenceUpdate('user123', 'cancel')
      */
-    async sendPresenceUpdate(chatId: EntityLike, action: 'typing' | 'cancel' = 'typing'): Promise<void> {
-        const typingAction =
-            action === 'typing' ? new Api.SendMessageTypingAction() : new Api.SendMessageCancelAction()
+    async sendPresenceUpdate(chatId: EntityLike, action: 'typing' | 'recording' | 'cancel' = 'typing'): Promise<void> {
+        let typingAction: Api.TypeSendMessageAction
+        if (action === 'recording') {
+            typingAction = new Api.SendMessageRecordAudioAction()
+        } else if (action === 'cancel') {
+            typingAction = new Api.SendMessageCancelAction()
+        } else {
+            typingAction = new Api.SendMessageTypingAction()
+        }
         await this.client.invoke(
             new Api.messages.SetTyping({
                 peer: chatId,


### PR DESCRIPTION
Implements typing indicator support in the Telegram provider using the
gramjs Api.messages.SetTyping with SendMessageTypingAction/SendMessageCancelAction,
matching the sendPresenceUpdate interface already present in Bailey and Meta providers.

https://claude.ai/code/session_01UmyKZN7rChAeT1ivrvzKhk