### PR TITLE
Add typing indicator method to MetaProvider

### DIFF
--- a/packages/provider-meta/__tests__/provider.test.ts
+++ b/packages/provider-meta/__tests__/provider.test.ts
@@ -1125,4 +1125,38 @@ describe('#MetaProvider', () => {
             })
         })
     })
+
+    describe('#typing', () => {
+        test('should send typing_on when called without duration', async () => {
+            // Arrange
+            const fakeRecipient = '1234567890'
+            jest.spyOn(metaProvider, 'sendPresenceUpdate').mockResolvedValue({ success: true })
+
+            // Act
+            await metaProvider.typing(fakeRecipient)
+
+            // Assert
+            expect(metaProvider.sendPresenceUpdate).toHaveBeenCalledTimes(1)
+            expect(metaProvider.sendPresenceUpdate).toHaveBeenCalledWith(fakeRecipient, 'typing_on')
+        })
+
+        test('should send typing_on then typing_off when called with duration', async () => {
+            // Arrange
+            const fakeRecipient = '1234567890'
+            jest.useFakeTimers()
+            jest.spyOn(metaProvider, 'sendPresenceUpdate').mockResolvedValue({ success: true })
+
+            // Act
+            const typingPromise = metaProvider.typing(fakeRecipient, 1000)
+            jest.runAllTimers()
+            await typingPromise
+
+            // Assert
+            expect(metaProvider.sendPresenceUpdate).toHaveBeenCalledTimes(2)
+            expect(metaProvider.sendPresenceUpdate).toHaveBeenNthCalledWith(1, fakeRecipient, 'typing_on')
+            expect(metaProvider.sendPresenceUpdate).toHaveBeenNthCalledWith(2, fakeRecipient, 'typing_off')
+
+            jest.useRealTimers()
+        })
+    })
 })

--- a/packages/provider-meta/src/interface/meta.ts
+++ b/packages/provider-meta/src/interface/meta.ts
@@ -55,4 +55,5 @@ export interface MetaInterface {
     sendAudio: (to: string, fileOpus: string, context: string | null) => void
     markAsRead: (wa_id: string) => Promise<any>
     sendPresenceUpdate: (to: string, status?: 'typing_on' | 'typing_off') => Promise<any>
+    typing: (to: string, ms?: number) => Promise<void>
 }

--- a/packages/provider-meta/src/meta/provider.ts
+++ b/packages/provider-meta/src/meta/provider.ts
@@ -1050,6 +1050,25 @@ class MetaProvider extends ProviderClass<MetaInterface> implements MetaInterface
     }
 
     /**
+     * Show a typing indicator to the recipient
+     * @param to - Recipient phone number
+     * @param ms - Optional duration in milliseconds after which the typing indicator is hidden automatically
+     * @example
+     * // Show typing indicator indefinitely
+     * await provider.typing('1234567890')
+     *
+     * // Show typing indicator for 3 seconds then hide it
+     * await provider.typing('1234567890', 3000)
+     */
+    typing = async (to: string, ms?: number): Promise<void> => {
+        await this.sendPresenceUpdate(to, 'typing_on')
+        if (ms) {
+            await new Promise((resolve) => setTimeout(resolve, ms))
+            await this.sendPresenceUpdate(to, 'typing_off')
+        }
+    }
+
+    /**
      * Queue a message to be sent via the Meta API (rate-limited)
      * @param body - Message body conforming to Meta API specification
      * @returns Promise with the API response


### PR DESCRIPTION
# Que tipo de Pull Request es?

- [x] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

Se agregó el método `typing()` a la clase `MetaProvider` para mostrar indicadores de escritura (typing indicators) a los destinatarios.

## Cambios principales

- **Nueva funcionalidad**: Método `typing(to: string, ms?: number)` que:
  - Envía `typing_on` para mostrar el indicador de escritura
  - Opcionalmente envía `typing_off` después de una duración especificada en milisegundos
  - Permite mostrar el indicador indefinidamente si no se proporciona duración

- **Interfaz actualizada**: Se agregó la firma del método a `MetaInterface`

- **Tests completos**: Se agregaron dos casos de prueba:
  - Verificar que se envía `typing_on` cuando se llama sin duración
  - Verificar que se envían `typing_on` y `typing_off` cuando se proporciona duración

## Ejemplos de uso

```typescript
// Mostrar indicador de escritura indefinidamente
await provider.typing('1234567890')

// Mostrar indicador de escritura por 3 segundos
await provider.typing('1234567890', 3000)
```

Los tests automatizados cubren ambos escenarios y validan que las llamadas a `sendPresenceUpdate` se realicen correctamente.

https://claude.ai/code/session_01GYBYgTGfb2K49NupMoGvCe