### PR TITLE
fix(provider-meta): update sendPresenceUpdate to use Meta Cloud API t…

### DIFF
--- a/packages/provider-meta/__tests__/provider.test.ts
+++ b/packages/provider-meta/__tests__/provider.test.ts
@@ -1074,87 +1074,54 @@ describe('#MetaProvider', () => {
     })
 
     describe('#sendPresenceUpdate', () => {
-        test('should send typing_on status by default', async () => {
+        test('should send typing_indicator with incoming message_id', async () => {
             // Arrange
-            const fakeRecipient = '1234567890'
+            const fakeMessageId = 'wamid.HBgLMTIzNDU2Nzg5MA=='
             jest.spyOn(metaProvider, 'sendMessageToApi').mockResolvedValue({ success: true })
 
             // Act
-            await metaProvider.sendPresenceUpdate(fakeRecipient)
+            await metaProvider.sendPresenceUpdate(fakeMessageId)
 
             // Assert
             expect(metaProvider.sendMessageToApi).toHaveBeenCalledWith({
                 messaging_product: 'whatsapp',
-                recipient_type: 'individual',
-                to: fakeRecipient,
-                type: 'typing_on',
-            })
-        })
-
-        test('should send typing_on status when explicitly specified', async () => {
-            // Arrange
-            const fakeRecipient = '1234567890'
-            jest.spyOn(metaProvider, 'sendMessageToApi').mockResolvedValue({ success: true })
-
-            // Act
-            await metaProvider.sendPresenceUpdate(fakeRecipient, 'typing_on')
-
-            // Assert
-            expect(metaProvider.sendMessageToApi).toHaveBeenCalledWith({
-                messaging_product: 'whatsapp',
-                recipient_type: 'individual',
-                to: fakeRecipient,
-                type: 'typing_on',
-            })
-        })
-
-        test('should send typing_off status when specified', async () => {
-            // Arrange
-            const fakeRecipient = '1234567890'
-            jest.spyOn(metaProvider, 'sendMessageToApi').mockResolvedValue({ success: true })
-
-            // Act
-            await metaProvider.sendPresenceUpdate(fakeRecipient, 'typing_off')
-
-            // Assert
-            expect(metaProvider.sendMessageToApi).toHaveBeenCalledWith({
-                messaging_product: 'whatsapp',
-                recipient_type: 'individual',
-                to: fakeRecipient,
-                type: 'typing_off',
+                status: 'read',
+                message_id: fakeMessageId,
+                typing_indicator: {
+                    type: 'text',
+                },
             })
         })
     })
 
     describe('#typing', () => {
-        test('should send typing_on when called without duration', async () => {
+        test('should call sendPresenceUpdate with messageId when called without duration', async () => {
             // Arrange
-            const fakeRecipient = '1234567890'
+            const fakeMessageId = 'wamid.HBgLMTIzNDU2Nzg5MA=='
             jest.spyOn(metaProvider, 'sendPresenceUpdate').mockResolvedValue({ success: true })
 
             // Act
-            await metaProvider.typing(fakeRecipient)
+            await metaProvider.typing(fakeMessageId)
 
             // Assert
             expect(metaProvider.sendPresenceUpdate).toHaveBeenCalledTimes(1)
-            expect(metaProvider.sendPresenceUpdate).toHaveBeenCalledWith(fakeRecipient, 'typing_on')
+            expect(metaProvider.sendPresenceUpdate).toHaveBeenCalledWith(fakeMessageId)
         })
 
-        test('should send typing_on then typing_off when called with duration', async () => {
+        test('should call sendPresenceUpdate then wait when called with duration', async () => {
             // Arrange
-            const fakeRecipient = '1234567890'
+            const fakeMessageId = 'wamid.HBgLMTIzNDU2Nzg5MA=='
             jest.useFakeTimers()
             jest.spyOn(metaProvider, 'sendPresenceUpdate').mockResolvedValue({ success: true })
 
             // Act
-            const typingPromise = metaProvider.typing(fakeRecipient, 1000)
+            const typingPromise = metaProvider.typing(fakeMessageId, 1000)
             jest.runAllTimers()
             await typingPromise
 
             // Assert
-            expect(metaProvider.sendPresenceUpdate).toHaveBeenCalledTimes(2)
-            expect(metaProvider.sendPresenceUpdate).toHaveBeenNthCalledWith(1, fakeRecipient, 'typing_on')
-            expect(metaProvider.sendPresenceUpdate).toHaveBeenNthCalledWith(2, fakeRecipient, 'typing_off')
+            expect(metaProvider.sendPresenceUpdate).toHaveBeenCalledTimes(1)
+            expect(metaProvider.sendPresenceUpdate).toHaveBeenCalledWith(fakeMessageId)
 
             jest.useRealTimers()
         })

--- a/packages/provider-meta/src/interface/meta.ts
+++ b/packages/provider-meta/src/interface/meta.ts
@@ -54,6 +54,6 @@ export interface MetaInterface {
     sendFile: (to: string, mediaInput: string | null, caption: string, context: string | null) => Promise<any>
     sendAudio: (to: string, fileOpus: string, context: string | null) => void
     markAsRead: (wa_id: string) => Promise<any>
-    sendPresenceUpdate: (to: string, status?: 'typing_on' | 'typing_off') => Promise<any>
-    typing: (to: string, ms?: number) => Promise<void>
+    sendPresenceUpdate: (messageId: string) => Promise<any>
+    typing: (messageId: string, ms?: number) => Promise<void>
 }

--- a/packages/provider-meta/src/meta/provider.ts
+++ b/packages/provider-meta/src/meta/provider.ts
@@ -1027,44 +1027,42 @@ class MetaProvider extends ProviderClass<MetaInterface> implements MetaInterface
     }
 
     /**
-     * Send presence update to simulate typing indicator
-     * @param to - Recipient phone number
-     * @param status - Presence status: 'typing_on' to show typing indicator, 'typing_off' to hide it
+     * Send presence update to simulate typing indicator using Meta Cloud API format.
+     * Requires the message_id of the incoming message that triggered this response.
+     * The typing indicator lasts up to 25 seconds or until a message is sent.
+     * @param messageId - The wamid of the incoming message (from the user)
      * @returns Promise with the API response
      * @example
-     * // Show typing indicator
-     * await provider.sendPresenceUpdate('1234567890')
-     *
-     * // Hide typing indicator
-     * await provider.sendPresenceUpdate('1234567890', 'typing_off')
+     * await provider.sendPresenceUpdate('wamid.HBgLMTIzNDU2Nzg5MA==')
      */
-    sendPresenceUpdate = async (to: string, status: 'typing_on' | 'typing_off' = 'typing_on') => {
-        to = parseMetaNumber(to)
+    sendPresenceUpdate = async (messageId: string) => {
         const body = {
             messaging_product: 'whatsapp',
-            recipient_type: 'individual',
-            to,
-            type: status,
+            status: 'read',
+            message_id: messageId,
+            typing_indicator: {
+                type: 'text',
+            },
         }
         return this.sendMessageToApi(body)
     }
 
     /**
-     * Show a typing indicator to the recipient
-     * @param to - Recipient phone number
-     * @param ms - Optional duration in milliseconds after which the typing indicator is hidden automatically
+     * Show a typing indicator to the recipient.
+     * Requires the message_id of the incoming message that triggered this response.
+     * @param messageId - The wamid of the incoming message (from the user)
+     * @param ms - Optional duration in milliseconds to wait (typing indicator disappears automatically after 25s or when a message is sent)
      * @example
-     * // Show typing indicator indefinitely
-     * await provider.typing('1234567890')
+     * // Show typing indicator
+     * await provider.typing('wamid.HBgLMTIzNDU2Nzg5MA==')
      *
-     * // Show typing indicator for 3 seconds then hide it
-     * await provider.typing('1234567890', 3000)
+     * // Show typing indicator and wait 3 seconds before continuing
+     * await provider.typing('wamid.HBgLMTIzNDU2Nzg5MA==', 3000)
      */
-    typing = async (to: string, ms?: number): Promise<void> => {
-        await this.sendPresenceUpdate(to, 'typing_on')
+    typing = async (messageId: string, ms?: number): Promise<void> => {
+        await this.sendPresenceUpdate(messageId)
         if (ms) {
             await new Promise((resolve) => setTimeout(resolve, ms))
-            await this.sendPresenceUpdate(to, 'typing_off')
         }
     }
 


### PR DESCRIPTION
…yping_indicator format

The previous implementation used `type: "typing_on"/"typing_off"` which is no longer supported by the Meta Cloud API and returns error 100. Updated to the current format that requires an incoming `message_id` (wamid) and uses `typing_indicator: { type: "text" }`.

- sendPresenceUpdate(messageId) now sends status:"read" + typing_indicator with the incoming wamid
- typing(messageId, ms?) no longer sends a "typing_off" call (not supported by Meta API; indicator disappears automatically after 25s or when a message is sent)
- Updated MetaInterface signatures accordingly
- Updated tests to match new API format

https://claude.ai/code/session_01GYBYgTGfb2K49NupMoGvCe

# Que tipo de Pull Request es?

- [ ] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

Por favor agrega una descripción de tu aporte para tener más contexto y poder avanzar más rápido. Si es de ayuda puedes usar plataformar como [https://www.loom.com/](https://www.loom.com/) para grabar un video.


> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
