### PR TITLE
feat(plugin-chatwoot): add Chatwoot plugin package for automatic CRM integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ log/*
 *.tgz
 lib
 tmp/
+!tmp/chatwoot-media/.gitkeep
 .yarn/*
 !.yarn/releases
 !.yarn/plugins/@yarnpkg/plugin-postinstall.cjs

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 /packages/portal/server
 /packages/*/starters
 /packages/*/node_modules
+/packages/*/*/node_modules
 /packages/*/dist
+/packages/*/*/dist
 /packages/*/*/tokens/*
 /packages/*/docs/dist
 /packages/provider/src/venom/tokens

--- a/lerna.json
+++ b/lerna.json
@@ -25,7 +25,8 @@
     "packages/provider-gohighlevel",
     "packages/provider-email",
     "packages/contexts-dialogflow",
-    "packages/contexts-dialogflow-cx"
+    "packages/contexts-dialogflow-cx",
+    "packages/plugins/chatwoot"
   ],
   "command": {
     "version": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "repository": "https://github.com/leifermendez/bot-whatsapp",
   "license": "ISC",
   "workspaces": [
+    "packages/plugins/*",
     "packages/bot",
     "packages/cli",
     "packages/create-builderbot",

--- a/packages/plugins/chatwoot/README.md
+++ b/packages/plugins/chatwoot/README.md
@@ -18,11 +18,13 @@
 | **Inbox auto-creation** | Creates an API-channel inbox on first run and reuses it on subsequent starts |
 | **Contact sync** | Finds or creates the Chatwoot contact for every phone number |
 | **Conversation sync** | Finds or creates the open conversation and caches it in memory |
-| **Media attachments** | Sends images/files received from WhatsApp as attachments in Chatwoot |
+| **Media attachments** | Images, audio, video and documents are sent as attachments in both directions |
+| **Media-only messages** | WhatsApp media-only messages (no caption) are synced with a readable label (`[image]`, `[audio]`, `[file]`, …) |
+| **Multiple attachments** | When an agent sends several files from Chatwoot, each one is forwarded to WhatsApp |
 | **Bidirectional messages** | Bot outgoing messages → Chatwoot (outgoing) · User messages → Chatwoot (incoming) |
-| **Agent replies** | Chatwoot agent messages → WhatsApp via `handleWebhook` |
+| **Agent replies** | Chatwoot agent messages → WhatsApp via webhook |
 | **Blacklist integration** | When an agent takes a conversation, the user is added to the bot blacklist so the bot stops responding |
-| **Webhook auto-registration** | Optionally registers the webhook URL in Chatwoot on startup |
+| **Webhook auto-registration** | Registers the webhook URL in Chatwoot and the HTTP route on the provider server automatically |
 | **Group message filter** | `@g.us` group messages are silently ignored |
 | **Startup validation** | Credentials are verified before anything runs; the plugin self-disables on failure |
 | **Serialized API calls** | An internal queue ensures no race conditions against the Chatwoot API |
@@ -48,6 +50,8 @@ const chatwoot = createChatwootPlugin({
     token: 'YOUR_CHATWOOT_USER_TOKEN',
     url: 'https://app.chatwoot.com',
     accountId: 1,
+    // Optional but recommended: enables agent → WhatsApp replies
+    webhookUrl: 'https://your-bot.example.com/v1/chatwoot',
 })
 
 const bot = await createBot({
@@ -56,11 +60,11 @@ const bot = await createBot({
     database: new MemoryDB(),
 })
 
-// One call wires everything up
+// One call wires everything up — including the webhook HTTP route
 await chatwoot.attach(bot)
 ```
 
-That's it. Every message exchanged through your bot is now mirrored in Chatwoot.
+That's it. Every message exchanged through your bot is now mirrored in Chatwoot, and agent replies are forwarded back to WhatsApp automatically.
 
 ---
 
@@ -107,12 +111,10 @@ https://app.chatwoot.com/app/accounts/42/conversations
 
 ## Receiving agent replies (webhook)
 
-When a Chatwoot agent sends a message, Chatwoot fires a webhook. You need to expose an HTTP endpoint and call `handleWebhook` inside it.
-
-### With BuilderBot's built-in HTTP server
+When a Chatwoot agent sends a message, Chatwoot fires a webhook to your bot. As long as you set `webhookUrl` in the config, `attach()` handles everything automatically — it registers the webhook in Chatwoot **and** wires the HTTP route on the provider's server.
 
 ```ts
-import { createBot, createFlow, addKeyword, handleCtx } from '@builderbot/bot'
+import { createBot, createFlow, addKeyword } from '@builderbot/bot'
 import { BaileysProvider } from '@builderbot/provider-baileys'
 import { createChatwootPlugin } from '@builderbot/plugin-chatwoot'
 
@@ -123,28 +125,29 @@ const chatwoot = createChatwootPlugin({
     webhookUrl: 'https://your-bot.example.com/v1/chatwoot',
 })
 
-const provider = createProvider(BaileysProvider, { name: 'bot' })
-
 const bot = await createBot({
     flow: createFlow([...]),
-    provider,
+    provider: createProvider(BaileysProvider, { name: 'bot' }),
     database: new MemoryDB(),
 })
 
+// Registers the Chatwoot account webhook AND the /v1/chatwoot HTTP route automatically
 await chatwoot.attach(bot)
-
-// Expose the webhook endpoint
-provider.server.post(
-    '/v1/chatwoot',
-    handleCtx(async (bot, req, res) => {
-        await chatwoot.handleWebhook(bot, req.body)
-        res.end(JSON.stringify({ status: 'ok' }))
-    })
-)
 ```
 
 > **Note:** The URL you pass as `webhookUrl` must be reachable by your Chatwoot server.  
 > For local development use [ngrok](https://ngrok.com/) or a similar tunnel.
+
+### Advanced: manual route registration
+
+If you use a custom HTTP server outside of BuilderBot's provider, you can still call `handleWebhook` directly:
+
+```ts
+myServer.post('/v1/chatwoot', async (req, res) => {
+    await chatwoot.handleWebhook(bot, req.body)
+    res.end(JSON.stringify({ status: 'ok' }))
+})
+```
 
 ### What `handleWebhook` handles
 
@@ -242,7 +245,30 @@ const chatwoot = createChatwootPlugin({
 
 ## Supported media types
 
-The plugin automatically detects the MIME type from the file extension when uploading attachments.
+The plugin handles media in both directions.
+
+### WhatsApp → Chatwoot
+
+When an incoming WhatsApp message carries media, the file is attached to the Chatwoot message. The plugin resolves the media source through two strategies, tried in order:
+
+1. **`options.media` URL** — used when the provider already exposes a public media URL in `payload.options.media`.
+2. **`provider.saveFile` fallback** — used when the provider carries the raw message context (e.g. Baileys) but does not populate `options.media`. The plugin calls `bot.provider.saveFile(payload)` to download the file to a temporary path, uploads it to Chatwoot, then cleans up the temp file automatically. If the download fails the message is still forwarded with the readable label as caption.
+
+If the message body is a provider event string, it is also converted to a human-readable caption that appears alongside the attachment:
+
+| WhatsApp event | Label shown in Chatwoot |
+|---|---|
+| `_event_media_` | `[image]` |
+| `_event_voice_note_` | `[audio]` |
+| `_event_document_` | `[file]` |
+| `_event_video_` | `[video]` |
+| `_event_location_` | `[location]` |
+| `_event_sticker_` | `[sticker]` |
+| `_event_order_` | `[order]` |
+
+### Chatwoot → WhatsApp
+
+When an agent uploads files in Chatwoot, each attachment is forwarded as a separate WhatsApp message. The plugin detects the MIME type from the file extension when uploading local files:
 
 | Extension | MIME type |
 |---|---|
@@ -252,8 +278,13 @@ The plugin automatically detects the MIME type from the file extension when uplo
 | `.webp` | `image/webp` |
 | `.mp4` | `video/mp4` |
 | `.pdf` | `application/pdf` |
-| `.mp3` / `.ogg` | `audio/mpeg` / `audio/ogg` |
+| `.mp3` | `audio/mpeg` |
+| `.ogg` / `.opus` | `audio/ogg` |
+| `.wav` | `audio/wav` |
+| `.svg` | `image/svg+xml` |
 | other | `application/octet-stream` |
+
+For remote URLs, the MIME type is taken from the HTTP `Content-Type` response header automatically.
 
 ---
 
@@ -269,7 +300,8 @@ Wires the plugin into the bot. Must be called once after `createBot`.
 
 - Validates Chatwoot credentials (`checkAccount`)
 - Finds or creates the API-channel inbox
-- Registers the webhook in Chatwoot if `webhookUrl` is configured
+- Registers the account webhook in Chatwoot if `webhookUrl` is configured
+- Auto-registers the HTTP route on `provider.server` if `webhookUrl` is configured
 - Listens to `send_message` and `provider.message` events
 
 ### `chatwoot.handleWebhook(bot, body)`

--- a/packages/plugins/chatwoot/README.md
+++ b/packages/plugins/chatwoot/README.md
@@ -1,0 +1,298 @@
+<p align="center">
+  <a href="https://builderbot.app/">
+    <h2 align="center">@builderbot/plugin-chatwoot</h2>
+  </a>
+</p>
+
+<p align="center">
+  Syncs every WhatsApp conversation to <a href="https://www.chatwoot.com/">Chatwoot</a> automatically.<br/>
+  Agents can reply directly from Chatwoot and their messages are forwarded to WhatsApp in real time.
+</p>
+
+---
+
+## What it does
+
+| Feature | Details |
+|---|---|
+| **Inbox auto-creation** | Creates an API-channel inbox on first run and reuses it on subsequent starts |
+| **Contact sync** | Finds or creates the Chatwoot contact for every phone number |
+| **Conversation sync** | Finds or creates the open conversation and caches it in memory |
+| **Media attachments** | Sends images/files received from WhatsApp as attachments in Chatwoot |
+| **Bidirectional messages** | Bot outgoing messages → Chatwoot (outgoing) · User messages → Chatwoot (incoming) |
+| **Agent replies** | Chatwoot agent messages → WhatsApp via `handleWebhook` |
+| **Blacklist integration** | When an agent takes a conversation, the user is added to the bot blacklist so the bot stops responding |
+| **Webhook auto-registration** | Optionally registers the webhook URL in Chatwoot on startup |
+| **Group message filter** | `@g.us` group messages are silently ignored |
+| **Startup validation** | Credentials are verified before anything runs; the plugin self-disables on failure |
+| **Serialized API calls** | An internal queue ensures no race conditions against the Chatwoot API |
+
+---
+
+## Installation
+
+```bash
+pnpm add @builderbot/plugin-chatwoot
+```
+
+---
+
+## Quick start
+
+```ts
+import { createBot, createProvider, createFlow, MemoryDB } from '@builderbot/bot'
+import { BaileysProvider } from '@builderbot/provider-baileys'
+import { createChatwootPlugin } from '@builderbot/plugin-chatwoot'
+
+const chatwoot = createChatwootPlugin({
+    token: 'YOUR_CHATWOOT_USER_TOKEN',
+    url: 'https://app.chatwoot.com',
+    accountId: 1,
+})
+
+const bot = await createBot({
+    flow: createFlow([...]),
+    provider: createProvider(BaileysProvider),
+    database: new MemoryDB(),
+})
+
+// One call wires everything up
+await chatwoot.attach(bot)
+```
+
+That's it. Every message exchanged through your bot is now mirrored in Chatwoot.
+
+---
+
+## Configuration
+
+```ts
+const chatwoot = createChatwootPlugin({
+    /** User or Agent API access token from Chatwoot → Profile → Access Token */
+    token: 'xxxxxxxxxxxxxxxxxxxxxxxx',
+
+    /** Base URL of your Chatwoot instance */
+    url: 'https://app.chatwoot.com',
+
+    /** Numeric account ID visible in the Chatwoot URL */
+    accountId: 1,
+
+    /** Optional: custom inbox name (default: 'BuilderBot Inbox') */
+    inboxName: 'WhatsApp Bot',
+
+    /**
+     * Optional: public URL where Chatwoot will POST webhook events.
+     * When provided, the plugin registers (or reuses) the webhook on startup.
+     * Required for agent replies to reach WhatsApp.
+     */
+    webhookUrl: 'https://your-bot.example.com/v1/chatwoot',
+})
+```
+
+### How to get your token
+
+1. Open Chatwoot → click your avatar (bottom-left) → **Profile Settings**
+2. Scroll down to **Access Token** and copy it
+
+### How to find your accountId
+
+It is the number in the URL after `/app/accounts/`:
+```
+https://app.chatwoot.com/app/accounts/42/conversations
+                                       ↑
+                                   accountId = 42
+```
+
+---
+
+## Receiving agent replies (webhook)
+
+When a Chatwoot agent sends a message, Chatwoot fires a webhook. You need to expose an HTTP endpoint and call `handleWebhook` inside it.
+
+### With BuilderBot's built-in HTTP server
+
+```ts
+import { createBot, createFlow, addKeyword, handleCtx } from '@builderbot/bot'
+import { BaileysProvider } from '@builderbot/provider-baileys'
+import { createChatwootPlugin } from '@builderbot/plugin-chatwoot'
+
+const chatwoot = createChatwootPlugin({
+    token: 'YOUR_TOKEN',
+    url: 'https://app.chatwoot.com',
+    accountId: 1,
+    webhookUrl: 'https://your-bot.example.com/v1/chatwoot',
+})
+
+const provider = createProvider(BaileysProvider, { name: 'bot' })
+
+const bot = await createBot({
+    flow: createFlow([...]),
+    provider,
+    database: new MemoryDB(),
+})
+
+await chatwoot.attach(bot)
+
+// Expose the webhook endpoint
+provider.server.post(
+    '/v1/chatwoot',
+    handleCtx(async (bot, req, res) => {
+        await chatwoot.handleWebhook(bot, req.body)
+        res.end(JSON.stringify({ status: 'ok' }))
+    })
+)
+```
+
+> **Note:** The URL you pass as `webhookUrl` must be reachable by your Chatwoot server.  
+> For local development use [ngrok](https://ngrok.com/) or a similar tunnel.
+
+### What `handleWebhook` handles
+
+| Chatwoot event | Plugin action |
+|---|---|
+| `conversation_updated` — agent **assigned** | Adds the user's phone to the bot blacklist (bot stops responding) |
+| `conversation_updated` — agent **unassigned** | Removes the phone from the blacklist (bot resumes) |
+| `message_created` — outgoing on API channel | Forwards the agent's message (text + optional media) to WhatsApp |
+| `message_created` — private note | Ignored — private notes are not forwarded |
+| Event for a different inbox | Ignored — only events for the plugin's inbox are processed |
+
+---
+
+## How agent takeover works
+
+```
+Agent assigned to conversation
+          │
+          ▼
+  phone added to blacklist ──► bot stops responding to that user
+          │
+  Agent types in Chatwoot
+          │
+          ▼
+  handleWebhook receives message_created
+          │
+          ▼
+  Message forwarded to WhatsApp
+
+Agent unassigns from conversation
+          │
+          ▼
+  phone removed from blacklist ──► bot resumes normally
+```
+
+---
+
+## Advanced usage
+
+### Accessing the Chatwoot API directly
+
+```ts
+const api = chatwoot.getApi()
+
+// Create a contact manually
+const contact = await api.findOrCreateContact('+5215511223344', 'John Doe')
+
+// Send a message to an existing conversation
+await api.sendMessage(conversationId, 'Hello from the API!', 'outgoing')
+
+// Send a message with a media attachment
+await api.sendMessage(conversationId, 'See attached', 'outgoing', 'https://example.com/image.png')
+// Or from a local file:
+await api.sendMessage(conversationId, 'See attached', 'outgoing', '/tmp/photo.jpg')
+```
+
+### Inspecting the active inbox
+
+```ts
+const inbox = chatwoot.getInbox()
+console.log(inbox?.id, inbox?.name)
+```
+
+### Checking plugin health
+
+```ts
+if (!chatwoot.status) {
+    console.warn('Chatwoot plugin is disabled — check your credentials')
+}
+```
+
+---
+
+## Environment variables (recommended)
+
+Store sensitive values in a `.env` file instead of hardcoding them:
+
+```env
+CHATWOOT_TOKEN=your-access-token
+CHATWOOT_URL=https://app.chatwoot.com
+CHATWOOT_ACCOUNT_ID=1
+CHATWOOT_WEBHOOK_URL=https://your-bot.example.com/v1/chatwoot
+```
+
+```ts
+const chatwoot = createChatwootPlugin({
+    token: process.env.CHATWOOT_TOKEN!,
+    url: process.env.CHATWOOT_URL!,
+    accountId: Number(process.env.CHATWOOT_ACCOUNT_ID),
+    webhookUrl: process.env.CHATWOOT_WEBHOOK_URL,
+})
+```
+
+---
+
+## Supported media types
+
+The plugin automatically detects the MIME type from the file extension when uploading attachments.
+
+| Extension | MIME type |
+|---|---|
+| `.jpg` / `.jpeg` | `image/jpeg` |
+| `.png` | `image/png` |
+| `.gif` | `image/gif` |
+| `.webp` | `image/webp` |
+| `.mp4` | `video/mp4` |
+| `.pdf` | `application/pdf` |
+| `.mp3` / `.ogg` | `audio/mpeg` / `audio/ogg` |
+| other | `application/octet-stream` |
+
+---
+
+## API reference
+
+### `createChatwootPlugin(config)`
+
+Creates the plugin instance. Returns a `ChatwootPlugin`.
+
+### `chatwoot.attach(bot)`
+
+Wires the plugin into the bot. Must be called once after `createBot`.
+
+- Validates Chatwoot credentials (`checkAccount`)
+- Finds or creates the API-channel inbox
+- Registers the webhook in Chatwoot if `webhookUrl` is configured
+- Listens to `send_message` and `provider.message` events
+
+### `chatwoot.handleWebhook(bot, body)`
+
+Processes a raw webhook body sent by Chatwoot. Call this from your HTTP route handler.
+
+### `chatwoot.getApi()`
+
+Returns the underlying `ChatwootApi` instance for direct API calls.
+
+### `chatwoot.getInbox()`
+
+Returns the `ChatwootInbox` object (`{ id, name }`) or `null` before `attach()`.
+
+### `chatwoot.status`
+
+`true` while the plugin is operational. Set to `false` automatically if credentials fail.
+
+---
+
+## Links
+
+- [BuilderBot documentation](https://builderbot.app/)
+- [Chatwoot documentation](https://www.chatwoot.com/docs/)
+- [💻 Discord](https://link.codigoencasa.com/DISCORD)
+- [👌 𝕏 (Twitter)](https://twitter.com/leifermendez)

--- a/packages/plugins/chatwoot/__tests__/chatwootPlugin.test.ts
+++ b/packages/plugins/chatwoot/__tests__/chatwootPlugin.test.ts
@@ -1,0 +1,55 @@
+import { test } from 'uvu'
+import * as assert from 'uvu/assert'
+
+import { ChatwootApi } from '../src/chatwootApi'
+import { ChatwootPlugin, createChatwootPlugin } from '../src/chatwootPlugin'
+
+const MOCK_CONFIG = {
+    token: 'test-token-123',
+    url: 'https://chatwoot.example.com',
+    accountId: 1,
+}
+
+test('createChatwootPlugin returns a ChatwootPlugin instance', () => {
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    assert.instance(plugin, ChatwootPlugin)
+})
+
+test('ChatwootPlugin exposes getApi()', () => {
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const api = plugin.getApi()
+    assert.instance(api, ChatwootApi)
+})
+
+test('ChatwootPlugin getInbox() returns null before attach', () => {
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    assert.is(plugin.getInbox(), null)
+})
+
+test('createChatwootPlugin uses default inbox name', () => {
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    assert.instance(plugin, ChatwootPlugin)
+})
+
+test('createChatwootPlugin accepts custom inbox name', () => {
+    const plugin = createChatwootPlugin({
+        ...MOCK_CONFIG,
+        inboxName: 'Custom Inbox',
+    })
+    assert.instance(plugin, ChatwootPlugin)
+})
+
+test('ChatwootApi constructs correct base URL', () => {
+    const api = new ChatwootApi(MOCK_CONFIG)
+    assert.instance(api, ChatwootApi)
+})
+
+test('ChatwootApi trims trailing slash from URL', () => {
+    const api = new ChatwootApi({
+        ...MOCK_CONFIG,
+        url: 'https://chatwoot.example.com/',
+    })
+    assert.instance(api, ChatwootApi)
+})
+
+test.run()

--- a/packages/plugins/chatwoot/__tests__/chatwootPlugin.test.ts
+++ b/packages/plugins/chatwoot/__tests__/chatwootPlugin.test.ts
@@ -81,9 +81,11 @@ const drainQueue = () => new Promise<void>((r) => setTimeout(r, 60))
 
 // ─── mock bot ─────────────────────────────────────────────────────────────────
 
-const makeMockBot = () => {
+const makeMockBot = (saveFileImpl?: (ctx: unknown, opts?: unknown) => Promise<string>) => {
     const botHandlers: Record<string, Array<(...a: unknown[]) => unknown>> = {}
     const provHandlers: Record<string, Array<(...a: unknown[]) => unknown>> = {}
+    const serverRoutes: Record<string, (req: any, res: any) => Promise<void>> = {}
+    const serverGetRoutes: Record<string, (req: any, res: any) => void> = {}
     return {
         on(ev: string, h: (...a: unknown[]) => unknown) {
             botHandlers[ev] = [...(botHandlers[ev] ?? []), h]
@@ -94,6 +96,17 @@ const makeMockBot = () => {
                 provHandlers[ev] = [...(provHandlers[ev] ?? []), h]
             },
             emit: (ev: string, payload: unknown) => Promise.all((provHandlers[ev] ?? []).map((h) => h(payload))),
+            server: {
+                routes: serverRoutes,
+                getRoutes: serverGetRoutes,
+                post(path: string, handler: (req: any, res: any) => Promise<void>) {
+                    serverRoutes[path] = handler
+                },
+                get(path: string, handler: (req: any, res: any) => void) {
+                    serverGetRoutes[path] = handler
+                },
+            },
+            ...(saveFileImpl ? { saveFile: saveFileImpl } : {}),
         },
         blacklist: {
             items: new Set<string>(),
@@ -360,6 +373,211 @@ test('ChatwootApi.sendMessage sends FormData when mediaSource is provided', asyn
 
 // ─── SimpleQueue serialization ────────────────────────────────────────────────
 
+// ─── media / _event_* normalization ──────────────────────────────────────────
+
+/** Extracts { content, message_type } from either a JSON string body or FormData. */
+const extractMessageBody = (body: unknown): { content: string; message_type: string } | null => {
+    if (body instanceof FormData) {
+        return { content: String(body.get('content') ?? ''), message_type: String(body.get('message_type') ?? '') }
+    }
+    if (typeof body === 'string') {
+        try {
+            return JSON.parse(body)
+        } catch {
+            return null
+        }
+    }
+    return null
+}
+
+test('provider message: _event_media_ with options.media sends empty content (attachment speaks for itself)', async () => {
+    const bodies: ReturnType<typeof extractMessageBody>[] = []
+    const { mock: baseMock } = makeSmartFetch()
+    const captureFetch: MockFn = async (url, opts) => {
+        if (String(url).includes('/messages') && opts?.method === 'POST') {
+            bodies.push(extractMessageBody(opts?.body))
+        }
+        return baseMock(url, opts)
+    }
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(baseMock, () => plugin.attach(bot as any))
+
+    await withFetch(captureFetch, async () => {
+        await bot.provider.emit('message', {
+            from: '5215511223344',
+            body: '_event_media_',
+            options: { media: 'https://example.com/photo.jpg' },
+        })
+        await drainQueue()
+    })
+
+    const msg = bodies.find((b) => b?.message_type === 'incoming')
+    assert.ok(msg, 'a message was sent to Chatwoot')
+    assert.is(msg?.content, '', 'media with no caption → empty content, no redundant [image] label')
+})
+
+test('provider message: _event_voice_note_ with options.media sends empty content', async () => {
+    const bodies: ReturnType<typeof extractMessageBody>[] = []
+    const { mock: baseMock } = makeSmartFetch()
+    const captureFetch: MockFn = async (url, opts) => {
+        if (String(url).includes('/messages') && opts?.method === 'POST') {
+            bodies.push(extractMessageBody(opts?.body))
+        }
+        return baseMock(url, opts)
+    }
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(baseMock, () => plugin.attach(bot as any))
+
+    await withFetch(captureFetch, async () => {
+        await bot.provider.emit('message', {
+            from: '5215511223344',
+            body: '_event_voice_note_',
+            options: { media: 'https://example.com/audio.ogg' },
+        })
+        await drainQueue()
+    })
+
+    const msg = bodies.find((b) => b?.message_type === 'incoming')
+    assert.ok(msg, 'a message was sent to Chatwoot')
+    assert.is(msg?.content, '', 'audio with media URL → empty content, no redundant [audio] label')
+})
+
+test('provider message: media-only message with empty body is still synced to Chatwoot', async () => {
+    const { mock, calls } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    const countAfterAttach = calls.length
+
+    await withFetch(mock, async () => {
+        await bot.provider.emit('message', {
+            from: '5215511223344',
+            body: '',
+            options: { media: 'https://example.com/photo.jpg' },
+        })
+        await drainQueue()
+    })
+
+    assert.ok(calls.length > countAfterAttach, 'fetch calls were made for media-only incoming message')
+})
+
+test('send_message: media-only bot message (empty content) is synced to Chatwoot', async () => {
+    const { mock, calls } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    const countAfterAttach = calls.length
+
+    await withFetch(mock, async () => {
+        await bot.emit('send_message', {
+            from: '5215511223344',
+            answer: '',
+            options: { media: 'https://example.com/image.png' },
+        })
+        await drainQueue()
+    })
+
+    assert.ok(calls.length > countAfterAttach, 'fetch calls were made for media-only outgoing message')
+})
+
+test('handleWebhook forwards all attachments when agent sends multiple files', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+
+    await plugin.handleWebhook(bot as any, {
+        event: 'message_created',
+        message_type: 'outgoing',
+        private: false,
+        content: 'See attached files',
+        attachments: [
+            { data_url: 'https://example.com/file1.pdf' },
+            { data_url: 'https://example.com/file2.png' },
+            { data_url: 'https://example.com/file3.mp4' },
+        ],
+        conversation: {
+            inbox_id: MOCK_INBOX.id,
+            channel: 'Channel::Api',
+            meta: { sender: { phone_number: '+5215511223344' } },
+        },
+    })
+
+    assert.is(bot.sent.length, 3, 'one sendMessage call per attachment')
+    assert.is((bot.sent[0].options as any)?.media, 'https://example.com/file1.pdf', 'first file with content')
+    assert.is(bot.sent[0].content, 'See attached files', 'text goes with first file')
+    assert.is((bot.sent[1].options as any)?.media, 'https://example.com/file2.png', 'second file separate')
+    assert.is((bot.sent[2].options as any)?.media, 'https://example.com/file3.mp4', 'third file separate')
+})
+
+// ─── auto HTTP route registration ────────────────────────────────────────────
+
+test('attach() auto-registers POST route on provider.server when webhookUrl is set', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin({ ...MOCK_CONFIG, webhookUrl: 'https://bot.example.com/v1/chatwoot' })
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    assert.ok(
+        bot.provider.server.routes['/v1/chatwoot'] !== undefined,
+        'POST route /v1/chatwoot should be registered on provider.server'
+    )
+})
+
+test('attach() does not register any route when webhookUrl is not set', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    assert.is(Object.keys(bot.provider.server.routes).length, 0, 'no routes should be registered without webhookUrl')
+})
+
+test('auto-registered route forwards agent message to WhatsApp', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin({ ...MOCK_CONFIG, webhookUrl: 'https://bot.example.com/v1/chatwoot' })
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+
+    const handler = bot.provider.server.routes['/v1/chatwoot']
+    assert.ok(handler, 'route handler must exist')
+
+    const mockRes = {
+        headers: {} as Record<string, string>,
+        body: '',
+        writeHead(_code: number, headers: Record<string, string>) {
+            this.headers = { ...this.headers, ...headers }
+        },
+        end(data: string) {
+            this.body = data
+        },
+    }
+
+    await handler(
+        {
+            body: {
+                event: 'message_created',
+                message_type: 'outgoing',
+                private: false,
+                content: 'Hello from agent via route',
+                conversation: {
+                    inbox_id: MOCK_INBOX.id,
+                    channel: 'Channel::Api',
+                    meta: { sender: { phone_number: '+5215511223344' } },
+                },
+            },
+        },
+        mockRes
+    )
+
+    assert.is(bot.sent.length, 1, 'sendMessage should be called once')
+    assert.is(bot.sent[0].number, '5215511223344', 'message sent to correct phone')
+    assert.is(bot.sent[0].content, 'Hello from agent via route', 'message content matches')
+    assert.is(mockRes.body, JSON.stringify({ status: 'ok' }), 'response body is { status: ok }')
+})
+
+// ─── SimpleQueue serialization ────────────────────────────────────────────────
+
 test('enqueued messages are processed without dropping', async () => {
     const { mock, calls } = makeSmartFetch()
     const plugin = createChatwootPlugin(MOCK_CONFIG)
@@ -373,6 +591,211 @@ test('enqueued messages are processed without dropping', async () => {
         await drainQueue()
     })
     assert.ok(calls.length > countAfterAttach, 'fetch calls were made for enqueued messages')
+})
+
+// ─── saveFile fallback + public URL (WA → Chatwoot, no options.media) ────────
+
+test('attach() registers GET /media/:filename route when webhookUrl and server.get are present', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin({ ...MOCK_CONFIG, webhookUrl: 'https://bot.example.com/v1/chatwoot' })
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    assert.ok(
+        bot.provider.server.getRoutes['/media/:filename'] !== undefined,
+        'GET /media/:filename route should be registered'
+    )
+})
+
+test('provider message: _event_media_ without options.media uses saveFile + public URL', async () => {
+    const SAVED_PATH = '/tmp/chatwoot-media/file-12345.jpg'
+    const bodies: ReturnType<typeof extractMessageBody>[] = []
+    const downloadedUrls: string[] = []
+
+    const saveFileMock = async (_ctx: unknown, _opts?: unknown): Promise<string> => SAVED_PATH
+
+    const { mock: baseMock } = makeSmartFetch()
+    const captureFetch: MockFn = async (url, opts) => {
+        if (String(url).includes('/messages') && opts?.method === 'POST') {
+            bodies.push(extractMessageBody(opts?.body))
+        }
+        // Capture media download attempts
+        if (String(url).includes('/media/')) {
+            downloadedUrls.push(String(url))
+        }
+        return baseMock(url, opts)
+    }
+
+    const plugin = createChatwootPlugin({ ...MOCK_CONFIG, webhookUrl: 'https://bot.example.com/v1/chatwoot' })
+    const bot = makeMockBot(saveFileMock)
+    await withFetch(baseMock, () => plugin.attach(bot as any))
+
+    await withFetch(captureFetch, async () => {
+        await bot.provider.emit('message', {
+            from: '5215511223344',
+            body: '_event_media_',
+            message: { imageMessage: { mimetype: 'image/jpeg' } },
+        })
+        await drainQueue()
+    })
+
+    const incoming = bodies.find((b) => b?.message_type === 'incoming')
+    assert.ok(incoming, 'a message was sent to Chatwoot')
+    assert.is(incoming?.content, '', 'image with no caption + media URL → empty content')
+    // The media was fetched from the public URL
+    assert.ok(
+        downloadedUrls.some((u) => u.includes('https://bot.example.com/media/file-12345.jpg')),
+        'plugin fetched media from the public /media URL'
+    )
+})
+
+test('provider message: saveFile failure falls back to label-only message', async () => {
+    const bodies: ReturnType<typeof extractMessageBody>[] = []
+
+    const failingSaveFile = async (_ctx: unknown, _opts?: unknown): Promise<string> => {
+        throw new Error('download failed')
+    }
+
+    const { mock: baseMock } = makeSmartFetch()
+    const captureFetch: MockFn = async (url, opts) => {
+        if (String(url).includes('/messages') && opts?.method === 'POST') {
+            bodies.push(extractMessageBody(opts?.body))
+        }
+        return baseMock(url, opts)
+    }
+
+    const plugin = createChatwootPlugin({ ...MOCK_CONFIG, webhookUrl: 'https://bot.example.com/v1/chatwoot' })
+    const bot = makeMockBot(failingSaveFile)
+    await withFetch(baseMock, () => plugin.attach(bot as any))
+
+    await withFetch(captureFetch, async () => {
+        await bot.provider.emit('message', {
+            from: '5215511223344',
+            body: '_event_media_',
+            message: { imageMessage: { mimetype: 'image/jpeg' } },
+        })
+        await drainQueue()
+    })
+
+    const incoming = bodies.find((b) => b?.message_type === 'incoming')
+    assert.ok(incoming, 'message still sent to Chatwoot even when saveFile throws')
+    assert.is(incoming?.content, '[image]', 'body still normalized to [image]')
+})
+
+test('provider message: image with caption sends real caption text instead of [image]', async () => {
+    const bodies: ReturnType<typeof extractMessageBody>[] = []
+
+    const { mock: baseMock } = makeSmartFetch()
+    const captureFetch: MockFn = async (url, opts) => {
+        if (String(url).includes('/messages') && opts?.method === 'POST') {
+            bodies.push(extractMessageBody(opts?.body))
+        }
+        return baseMock(url, opts)
+    }
+
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(baseMock, () => plugin.attach(bot as any))
+
+    await withFetch(captureFetch, async () => {
+        await bot.provider.emit('message', {
+            from: '5215511223344',
+            body: '_event_media_',
+            // Baileys raw WAMessage with a caption
+            message: { imageMessage: { mimetype: 'image/jpeg', caption: 'Check this out!' } },
+        })
+        await drainQueue()
+    })
+
+    const incoming = bodies.find((b) => b?.message_type === 'incoming')
+    assert.ok(incoming, 'a message was sent to Chatwoot')
+    assert.is(incoming?.content, 'Check this out!', 'real caption replaces [image] label')
+})
+
+test('provider message: image without caption sends empty content (no redundant [image] label)', async () => {
+    const bodies: ReturnType<typeof extractMessageBody>[] = []
+
+    const SAVED_PATH = '/tmp/chatwoot-media/file-99.jpg'
+    const saveFileMock = async (_ctx: unknown, _opts?: unknown): Promise<string> => SAVED_PATH
+
+    const { mock: baseMock } = makeSmartFetch()
+    const captureFetch: MockFn = async (url, opts) => {
+        if (String(url).includes('/messages') && opts?.method === 'POST') {
+            bodies.push(extractMessageBody(opts?.body))
+        }
+        return baseMock(url, opts)
+    }
+
+    const plugin = createChatwootPlugin({ ...MOCK_CONFIG, webhookUrl: 'https://bot.example.com/v1/chatwoot' })
+    const bot = makeMockBot(saveFileMock)
+    await withFetch(baseMock, () => plugin.attach(bot as any))
+
+    await withFetch(captureFetch, async () => {
+        await bot.provider.emit('message', {
+            from: '5215511223344',
+            body: '_event_media_',
+            message: { imageMessage: { mimetype: 'image/jpeg', caption: '' } },
+        })
+        await drainQueue()
+    })
+
+    const incoming = bodies.find((b) => b?.message_type === 'incoming')
+    assert.ok(incoming, 'a message was sent to Chatwoot')
+    assert.is(incoming?.content, '', 'no caption + media URL → empty content, no redundant label')
+})
+
+test('provider message: video with caption sends real caption text', async () => {
+    const bodies: ReturnType<typeof extractMessageBody>[] = []
+
+    const { mock: baseMock } = makeSmartFetch()
+    const captureFetch: MockFn = async (url, opts) => {
+        if (String(url).includes('/messages') && opts?.method === 'POST') {
+            bodies.push(extractMessageBody(opts?.body))
+        }
+        return baseMock(url, opts)
+    }
+
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(baseMock, () => plugin.attach(bot as any))
+
+    await withFetch(captureFetch, async () => {
+        await bot.provider.emit('message', {
+            from: '5215511223344',
+            body: '_event_media_',
+            message: { videoMessage: { mimetype: 'video/mp4', caption: 'Watch this video' } },
+        })
+        await drainQueue()
+    })
+
+    const incoming = bodies.find((b) => b?.message_type === 'incoming')
+    assert.ok(incoming, 'a message was sent to Chatwoot')
+    assert.is(incoming?.content, 'Watch this video', 'video caption is used as content')
+})
+
+test('provider message: no saveFile on provider sends [image] label as last-resort fallback', async () => {
+    const bodies: ReturnType<typeof extractMessageBody>[] = []
+
+    const { mock: baseMock } = makeSmartFetch()
+    const captureFetch: MockFn = async (url, opts) => {
+        if (String(url).includes('/messages') && opts?.method === 'POST') {
+            bodies.push(extractMessageBody(opts?.body))
+        }
+        return baseMock(url, opts)
+    }
+
+    // No saveFile, no options.media → no mediaUrl → falls back to normalizeBody label
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(baseMock, () => plugin.attach(bot as any))
+
+    await withFetch(captureFetch, async () => {
+        await bot.provider.emit('message', { from: '5215511223344', body: '_event_media_' })
+        await drainQueue()
+    })
+
+    const incoming = bodies.find((b) => b?.message_type === 'incoming')
+    assert.ok(incoming, 'message sent to Chatwoot without saveFile')
+    assert.is(incoming?.content, '[image]', 'no media URL → [image] label used as fallback')
 })
 
 test.run()

--- a/packages/plugins/chatwoot/__tests__/chatwootPlugin.test.ts
+++ b/packages/plugins/chatwoot/__tests__/chatwootPlugin.test.ts
@@ -4,52 +4,375 @@ import * as assert from 'uvu/assert'
 import { ChatwootApi } from '../src/chatwootApi'
 import { ChatwootPlugin, createChatwootPlugin } from '../src/chatwootPlugin'
 
+// ─── config ───────────────────────────────────────────────────────────────────
+
 const MOCK_CONFIG = {
     token: 'test-token-123',
     url: 'https://chatwoot.example.com',
     accountId: 1,
 }
 
+const MOCK_INBOX = { id: 42, name: 'BuilderBot Inbox' }
+
+// ─── fetch mock ───────────────────────────────────────────────────────────────
+
+type MockFn = (url: string, opts?: RequestInit) => Promise<Response>
+
+/**
+ * Smart fetch mock: matches requests by method + URL substring.
+ * More specific entries (longer path strings) win over shorter ones.
+ */
+const makeSmartFetch = (overrides: Record<string, unknown> = {}): { mock: MockFn; calls: string[] } => {
+    const calls: string[] = []
+
+    const defaults: Record<string, unknown> = {
+        'GET /api/v1/accounts/1/': { id: 1 },
+        'GET /inboxes': { payload: [MOCK_INBOX] },
+        'POST /inboxes': MOCK_INBOX,
+        'GET /webhooks': { payload: { webhooks: [] } },
+        'POST /webhooks': { id: 1, url: '' },
+        'GET /contacts/search': { payload: [] },
+        'GET /conversations': { payload: [] },
+        'POST /contacts': { payload: { contact: { id: 10 } } },
+        'POST /conversations': { id: 99, inbox_id: 42, contact_id: 10 },
+        'POST /messages': { id: 1, content: 'ok', message_type: 'outgoing' },
+        ...overrides,
+    }
+
+    const mock: MockFn = async (url, opts) => {
+        const method = (opts?.method ?? 'GET').toUpperCase()
+        calls.push(`${method} ${String(url)}`)
+
+        const key = Object.keys(defaults)
+            .sort((a, b) => b.length - a.length)
+            .find((k) => {
+                const space = k.indexOf(' ')
+                const kMethod = k.slice(0, space)
+                const kPath = k.slice(space + 1)
+                return kMethod === method && String(url).includes(kPath)
+            })
+
+        const body = key !== undefined ? defaults[key] : {}
+        return {
+            ok: true,
+            json: async () => body,
+            text: async () => JSON.stringify(body),
+            headers: new Headers({ 'content-type': 'application/json' }),
+            arrayBuffer: async () => new ArrayBuffer(0),
+        } as unknown as Response
+    }
+
+    return { mock, calls }
+}
+
+/** Temporarily replace global.fetch, restore after fn resolves. */
+const withFetch = async <T>(mockFn: MockFn, fn: () => Promise<T>): Promise<T> => {
+    const original = (global as any).fetch
+    ;(global as any).fetch = mockFn
+    try {
+        return await fn()
+    } finally {
+        ;(global as any).fetch = original
+    }
+}
+
+/** Wait for the internal SimpleQueue to drain. */
+const drainQueue = () => new Promise<void>((r) => setTimeout(r, 60))
+
+// ─── mock bot ─────────────────────────────────────────────────────────────────
+
+const makeMockBot = () => {
+    const botHandlers: Record<string, Array<(...a: unknown[]) => unknown>> = {}
+    const provHandlers: Record<string, Array<(...a: unknown[]) => unknown>> = {}
+    return {
+        on(ev: string, h: (...a: unknown[]) => unknown) {
+            botHandlers[ev] = [...(botHandlers[ev] ?? []), h]
+        },
+        emit: (ev: string, payload: unknown) => Promise.all((botHandlers[ev] ?? []).map((h) => h(payload))),
+        provider: {
+            on(ev: string, h: (...a: unknown[]) => unknown) {
+                provHandlers[ev] = [...(provHandlers[ev] ?? []), h]
+            },
+            emit: (ev: string, payload: unknown) => Promise.all((provHandlers[ev] ?? []).map((h) => h(payload))),
+        },
+        blacklist: {
+            items: new Set<string>(),
+            add(p: string) {
+                this.items.add(p)
+            },
+            remove(p: string) {
+                this.items.delete(p)
+            },
+            checkIf(p: string) {
+                return this.items.has(p)
+            },
+        },
+        sent: [] as Array<{ number: string; content: string; options?: unknown }>,
+        async sendMessage(number: string, content: string, options?: unknown) {
+            this.sent.push({ number, content, options })
+        },
+    }
+}
+
+// ─── existing construction tests ─────────────────────────────────────────────
+
 test('createChatwootPlugin returns a ChatwootPlugin instance', () => {
-    const plugin = createChatwootPlugin(MOCK_CONFIG)
-    assert.instance(plugin, ChatwootPlugin)
+    assert.instance(createChatwootPlugin(MOCK_CONFIG), ChatwootPlugin)
 })
 
 test('ChatwootPlugin exposes getApi()', () => {
-    const plugin = createChatwootPlugin(MOCK_CONFIG)
-    const api = plugin.getApi()
-    assert.instance(api, ChatwootApi)
+    assert.instance(createChatwootPlugin(MOCK_CONFIG).getApi(), ChatwootApi)
 })
 
 test('ChatwootPlugin getInbox() returns null before attach', () => {
-    const plugin = createChatwootPlugin(MOCK_CONFIG)
-    assert.is(plugin.getInbox(), null)
+    assert.is(createChatwootPlugin(MOCK_CONFIG).getInbox(), null)
 })
 
 test('createChatwootPlugin uses default inbox name', () => {
-    const plugin = createChatwootPlugin(MOCK_CONFIG)
-    assert.instance(plugin, ChatwootPlugin)
+    assert.instance(createChatwootPlugin(MOCK_CONFIG), ChatwootPlugin)
 })
 
 test('createChatwootPlugin accepts custom inbox name', () => {
-    const plugin = createChatwootPlugin({
-        ...MOCK_CONFIG,
-        inboxName: 'Custom Inbox',
-    })
-    assert.instance(plugin, ChatwootPlugin)
+    assert.instance(createChatwootPlugin({ ...MOCK_CONFIG, inboxName: 'Custom Inbox' }), ChatwootPlugin)
 })
 
-test('ChatwootApi constructs correct base URL', () => {
-    const api = new ChatwootApi(MOCK_CONFIG)
-    assert.instance(api, ChatwootApi)
+test('ChatwootApi constructs with correct base URL', () => {
+    assert.instance(new ChatwootApi(MOCK_CONFIG), ChatwootApi)
 })
 
 test('ChatwootApi trims trailing slash from URL', () => {
-    const api = new ChatwootApi({
-        ...MOCK_CONFIG,
-        url: 'https://chatwoot.example.com/',
+    assert.instance(new ChatwootApi({ ...MOCK_CONFIG, url: 'https://chatwoot.example.com/' }), ChatwootApi)
+})
+
+// ─── status flag ─────────────────────────────────────────────────────────────
+
+test('plugin status is true by default', () => {
+    assert.is(createChatwootPlugin(MOCK_CONFIG).status, true)
+})
+
+test('attach() sets status=false and skips inbox when credentials are invalid', async () => {
+    const { mock } = makeSmartFetch({ 'GET /api/v1/accounts/1/': { error: 'unauthorized' } })
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    assert.is(plugin.status, false)
+    assert.is(plugin.getInbox(), null)
+})
+
+test('attach() sets inbox and keeps status=true when credentials are valid', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    assert.is(plugin.status, true)
+    assert.is(plugin.getInbox()?.id, MOCK_INBOX.id)
+})
+
+// ─── webhook auto-creation ────────────────────────────────────────────────────
+
+test('attach() registers webhook when webhookUrl is configured', async () => {
+    const { mock, calls } = makeSmartFetch()
+    const plugin = createChatwootPlugin({ ...MOCK_CONFIG, webhookUrl: 'https://bot.example.com/chatwoot' })
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    assert.ok(
+        calls.some((c) => c.startsWith('POST') && c.includes('/webhooks')),
+        'POST /webhooks was called to register the webhook'
+    )
+})
+
+test('attach() skips webhook registration when webhookUrl is not configured', async () => {
+    const { mock, calls } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    assert.not.ok(
+        calls.some((c) => c.startsWith('POST') && c.includes('/webhooks')),
+        'POST /webhooks should not be called without webhookUrl'
+    )
+})
+
+// ─── group filter ─────────────────────────────────────────────────────────────
+
+test('send_message handler skips @g.us group messages', async () => {
+    const { mock, calls } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    const countAfterAttach = calls.length
+
+    await withFetch(mock, async () => {
+        await bot.emit('send_message', { from: '1234567890@g.us', answer: 'Hello group' })
+        await drainQueue()
     })
-    assert.instance(api, ChatwootApi)
+    assert.is(calls.length, countAfterAttach, 'no fetch calls for group send_message')
+})
+
+test('provider message handler skips @g.us group messages', async () => {
+    const { mock, calls } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    const countAfterAttach = calls.length
+
+    await withFetch(mock, async () => {
+        await bot.provider.emit('message', { from: '9876543210@g.us', body: 'Group message' })
+        await drainQueue()
+    })
+    assert.is(calls.length, countAfterAttach, 'no fetch calls for group provider message')
+})
+
+// ─── handleWebhook ────────────────────────────────────────────────────────────
+
+test('handleWebhook returns early when inbox ID does not match', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+
+    await plugin.handleWebhook(bot as any, {
+        event: 'message_created',
+        message_type: 'outgoing',
+        private: false,
+        content: 'Should be ignored',
+        conversation: { inbox_id: 9999, channel: 'Channel::Api', meta: { sender: { phone_number: '+1234' } } },
+    })
+    assert.is(bot.sent.length, 0, 'sendMessage not called for mismatched inbox')
+})
+
+test('handleWebhook adds phone to blacklist when agent is assigned', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+
+    await plugin.handleWebhook(bot as any, {
+        event: 'conversation_updated',
+        changed_attributes: [{ assignee_id: { current_value: 7 } }],
+        meta: { sender: { phone_number: '+5215511223344' } },
+        conversation: { inbox_id: MOCK_INBOX.id },
+    })
+    assert.ok(bot.blacklist.items.has('5215511223344'), 'phone added to blacklist')
+})
+
+test('handleWebhook removes phone from blacklist when agent is unassigned', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+
+    bot.blacklist.items.add('5215511223344')
+
+    await plugin.handleWebhook(bot as any, {
+        event: 'conversation_updated',
+        changed_attributes: [{ assignee_id: { current_value: null } }],
+        meta: { sender: { phone_number: '+5215511223344' } },
+        conversation: { inbox_id: MOCK_INBOX.id },
+    })
+    assert.not.ok(bot.blacklist.items.has('5215511223344'), 'phone removed from blacklist')
+})
+
+test('handleWebhook forwards outgoing API channel message to WhatsApp', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+
+    await plugin.handleWebhook(bot as any, {
+        event: 'message_created',
+        message_type: 'outgoing',
+        private: false,
+        content: 'Hello from agent',
+        conversation: {
+            inbox_id: MOCK_INBOX.id,
+            channel: 'Channel::Api',
+            meta: { sender: { phone_number: '+5215511223344' } },
+        },
+    })
+    assert.is(bot.sent.length, 1, 'sendMessage called once')
+    assert.is(bot.sent[0].number, '5215511223344')
+    assert.is(bot.sent[0].content, 'Hello from agent')
+})
+
+test('handleWebhook does not forward private messages to WhatsApp', async () => {
+    const { mock } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+
+    await plugin.handleWebhook(bot as any, {
+        event: 'message_created',
+        message_type: 'outgoing',
+        private: true,
+        content: 'Internal agent note',
+        conversation: {
+            inbox_id: MOCK_INBOX.id,
+            channel: 'Channel::Api',
+            meta: { sender: { phone_number: '+5215511223344' } },
+        },
+    })
+    assert.is(bot.sent.length, 0, 'private message must not be forwarded')
+})
+
+test('handleWebhook is a no-op before attach()', async () => {
+    const bot = makeMockBot()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    await plugin.handleWebhook(bot as any, {
+        event: 'message_created',
+        message_type: 'outgoing',
+        private: false,
+        content: 'Should be ignored',
+        conversation: { inbox_id: 42, channel: 'Channel::Api' },
+    })
+    assert.is(bot.sent.length, 0, 'no action before attach')
+})
+
+// ─── media support ────────────────────────────────────────────────────────────
+
+test('ChatwootApi.sendMessage sends JSON when no media is provided', async () => {
+    const { mock, calls } = makeSmartFetch()
+    const api = new ChatwootApi(MOCK_CONFIG)
+    await withFetch(mock, () => api.sendMessage(1, 'hello', 'outgoing'))
+    assert.ok(
+        calls.some((c) => c.startsWith('POST') && c.includes('/messages')),
+        'POST /messages called for text message'
+    )
+})
+
+test('ChatwootApi.sendMessage sends FormData when mediaSource is provided', async () => {
+    const bodies: unknown[] = []
+    const captureFetch: MockFn = async (_url, opts) => {
+        bodies.push(opts?.body)
+        return {
+            ok: true,
+            json: async () => ({ id: 1, content: 'ok', message_type: 'outgoing' }),
+            text: async () => '{}',
+            headers: new Headers({ 'content-type': 'application/json' }),
+            // arrayBuffer is needed for the media download step
+            arrayBuffer: async () => new ArrayBuffer(8),
+        } as unknown as Response
+    }
+    const api = new ChatwootApi(MOCK_CONFIG)
+    await withFetch(captureFetch, () => api.sendMessage(1, 'with media', 'outgoing', 'https://example.com/image.png'))
+    const formDataBody = bodies.find((b) => b instanceof FormData)
+    assert.instance(formDataBody, FormData, 'a POST body should be FormData when media is provided')
+})
+
+// ─── SimpleQueue serialization ────────────────────────────────────────────────
+
+test('enqueued messages are processed without dropping', async () => {
+    const { mock, calls } = makeSmartFetch()
+    const plugin = createChatwootPlugin(MOCK_CONFIG)
+    const bot = makeMockBot()
+    await withFetch(mock, () => plugin.attach(bot as any))
+    const countAfterAttach = calls.length
+
+    await withFetch(mock, async () => {
+        await bot.emit('send_message', { from: '5215511223344', answer: 'msg1' })
+        await bot.emit('send_message', { from: '5215511223344', answer: 'msg2' })
+        await drainQueue()
+    })
+    assert.ok(calls.length > countAfterAttach, 'fetch calls were made for enqueued messages')
 })
 
 test.run()

--- a/packages/plugins/chatwoot/package.json
+++ b/packages/plugins/chatwoot/package.json
@@ -1,0 +1,46 @@
+{
+    "name": "@builderbot/plugin-chatwoot",
+    "version": "1.3.15-alpha.21",
+    "description": "Plugin de Chatwoot para BuilderBot - Crea inbox, guarda contactos y sincroniza conversaciones automáticamente",
+    "keywords": ["chatwoot", "builderbot", "plugin", "crm", "customer-support"],
+    "author": "Leifer Mendez <leifer33@gmail.com>",
+    "license": "ISC",
+    "main": "dist/index.cjs",
+    "types": "dist/index.d.ts",
+    "type": "module",
+    "directories": {
+        "src": "src",
+        "test": "__tests__"
+    },
+    "files": [
+        "./dist/"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/codigoencasa/bot-whatsapp.git"
+    },
+    "scripts": {
+        "build": "rimraf dist && rollup --config",
+        "test": "npx uvu -r tsm ./__tests__ .test.ts",
+        "test:coverage": "npx c8 npm run test",
+        "test:debug": "npx tsm --inspect-brk ../../node_modules/uvu/bin.js ./__tests__ .test.ts"
+    },
+    "bugs": {
+        "url": "https://github.com/codigoencasa/bot-whatsapp/issues"
+    },
+    "homepage": "https://github.com/codigoencasa/bot-whatsapp#readme",
+    "dependencies": {
+        "@builderbot/bot": "^1.3.15-alpha.21"
+    },
+    "devDependencies": {
+        "@rollup/plugin-commonjs": "^29.0.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@types/node": "^24.10.2",
+        "rimraf": "^6.1.2",
+        "rollup-plugin-typescript2": "^0.36.0",
+        "tslib": "^2.6.2",
+        "tsm": "^2.3.0"
+    },
+    "gitHead": "8ca5bde13fa8276a8bdeac9877df107aba0bc20b"
+}

--- a/packages/plugins/chatwoot/package.json
+++ b/packages/plugins/chatwoot/package.json
@@ -7,7 +7,13 @@
     "license": "ISC",
     "main": "dist/index.cjs",
     "types": "dist/index.d.ts",
-    "type": "module",
+    "exports": {
+        ".": {
+            "import": "./dist/index.mjs",
+            "require": "./dist/index.cjs",
+            "types": "./dist/index.d.ts"
+        }
+    },
     "directories": {
         "src": "src",
         "test": "__tests__"
@@ -22,7 +28,7 @@
     "scripts": {
         "build": "rimraf dist && rollup --config",
         "test": "npx uvu -r tsm ./__tests__ .test.ts",
-        "test:coverage": "npx c8 npm run test",
+        "test:coverage": "npx c8 pnpm test",
         "test:debug": "npx tsm --inspect-brk ../../node_modules/uvu/bin.js ./__tests__ .test.ts"
     },
     "bugs": {
@@ -35,11 +41,10 @@
     "devDependencies": {
         "@rollup/plugin-commonjs": "^29.0.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
-        "@rollup/plugin-terser": "^0.4.4",
         "@types/node": "^24.10.2",
         "rimraf": "^6.1.2",
         "rollup-plugin-typescript2": "^0.36.0",
-        "tslib": "^2.6.2",
+        "tslib": "^2.8.1",
         "tsm": "^2.3.0"
     },
     "gitHead": "8ca5bde13fa8276a8bdeac9877df107aba0bc20b"

--- a/packages/plugins/chatwoot/rollup.config.js
+++ b/packages/plugins/chatwoot/rollup.config.js
@@ -1,0 +1,21 @@
+import typescript from 'rollup-plugin-typescript2'
+import { nodeResolve } from '@rollup/plugin-node-resolve'
+import commonjs from '@rollup/plugin-commonjs'
+export default {
+    input: ['src/index.ts'],
+    output: [
+        {
+            dir: 'dist',
+            entryFileNames: '[name].cjs',
+            format: 'cjs',
+            exports: 'named',
+        },
+    ],
+    plugins: [
+        commonjs(),
+        nodeResolve({
+            resolveOnly: (module) => !/@builderbot\/bot/i.test(module),
+        }),
+        typescript(),
+    ],
+}

--- a/packages/plugins/chatwoot/rollup.config.js
+++ b/packages/plugins/chatwoot/rollup.config.js
@@ -10,6 +10,11 @@ export default {
             format: 'cjs',
             exports: 'named',
         },
+        {
+            dir: 'dist',
+            entryFileNames: '[name].mjs',
+            format: 'esm',
+        },
     ],
     plugins: [
         commonjs(),

--- a/packages/plugins/chatwoot/src/chatwootApi.ts
+++ b/packages/plugins/chatwoot/src/chatwootApi.ts
@@ -1,0 +1,190 @@
+import type {
+    ChatwootContact,
+    ChatwootConversation,
+    ChatwootInbox,
+    ChatwootMessage,
+    ChatwootPluginConfig,
+    ChatwootSearchContactsPayload,
+} from './types'
+
+class ChatwootApi {
+    private baseUrl: string
+    private headers: Record<string, string>
+    private accountId: number
+
+    constructor(config: ChatwootPluginConfig) {
+        this.baseUrl = `${config.url.replace(/\/$/, '')}/api/v1/accounts/${config.accountId}`
+        this.accountId = config.accountId
+        this.headers = {
+            'Content-Type': 'application/json',
+            api_access_token: config.token,
+        }
+    }
+
+    /**
+     * Crea un inbox tipo API channel en Chatwoot.
+     * Si ya existe uno con el mismo nombre, lo retorna.
+     */
+    async findOrCreateInbox(name: string): Promise<ChatwootInbox> {
+        const existing = await this.listInboxes()
+        const found = existing.find((inbox) => inbox.name === name)
+        if (found) return found
+
+        const response = await fetch(`${this.baseUrl}/inboxes`, {
+            method: 'POST',
+            headers: this.headers,
+            body: JSON.stringify({
+                name,
+                channel: {
+                    type: 'api',
+                    webhook_url: '',
+                },
+            }),
+        })
+
+        if (!response.ok) {
+            const error = await response.text()
+            throw new Error(`[Chatwoot] Error creating inbox: ${error}`)
+        }
+
+        return (await response.json()) as ChatwootInbox
+    }
+
+    /**
+     * Lista todos los inboxes de la cuenta.
+     */
+    async listInboxes(): Promise<ChatwootInbox[]> {
+        const response = await fetch(`${this.baseUrl}/inboxes`, {
+            method: 'GET',
+            headers: this.headers,
+        })
+
+        if (!response.ok) return []
+
+        const data = (await response.json()) as { payload: ChatwootInbox[] }
+        return data?.payload ?? []
+    }
+
+    /**
+     * Busca un contacto por teléfono. Si no existe, lo crea.
+     */
+    async findOrCreateContact(phone: string, name?: string): Promise<ChatwootContact> {
+        const found = await this.searchContacts(phone)
+        if (found) return found
+
+        return this.createContact(phone, name)
+    }
+
+    /**
+     * Busca contactos por query (teléfono, nombre, email).
+     */
+    async searchContacts(query: string): Promise<ChatwootContact | null> {
+        const response = await fetch(`${this.baseUrl}/contacts/search?q=${encodeURIComponent(query)}`, {
+            method: 'GET',
+            headers: this.headers,
+        })
+
+        if (!response.ok) return null
+
+        const data = (await response.json()) as ChatwootSearchContactsPayload
+        return data?.payload?.[0] ?? null
+    }
+
+    /**
+     * Crea un nuevo contacto en Chatwoot.
+     */
+    async createContact(phone: string, name?: string): Promise<ChatwootContact> {
+        const response = await fetch(`${this.baseUrl}/contacts`, {
+            method: 'POST',
+            headers: this.headers,
+            body: JSON.stringify({
+                name: name ?? phone,
+                phone_number: phone.startsWith('+') ? phone : `+${phone}`,
+                identifier: phone,
+            }),
+        })
+
+        if (!response.ok) {
+            const error = await response.text()
+            throw new Error(`[Chatwoot] Error creating contact: ${error}`)
+        }
+
+        const data = (await response.json()) as { payload: { contact: ChatwootContact } }
+        return data?.payload?.contact ?? (data as unknown as ChatwootContact)
+    }
+
+    /**
+     * Busca una conversación abierta para un contacto en un inbox.
+     * Si no existe, crea una nueva.
+     */
+    async findOrCreateConversation(contactId: number, inboxId: number): Promise<ChatwootConversation> {
+        const existing = await this.getContactConversations(contactId)
+        const open = existing.find((conv) => conv.inbox_id === inboxId && conv.status !== 'resolved')
+        if (open) return open
+
+        return this.createConversation(contactId, inboxId)
+    }
+
+    /**
+     * Obtiene las conversaciones de un contacto.
+     */
+    async getContactConversations(contactId: number): Promise<ChatwootConversation[]> {
+        const response = await fetch(`${this.baseUrl}/contacts/${contactId}/conversations`, {
+            method: 'GET',
+            headers: this.headers,
+        })
+
+        if (!response.ok) return []
+
+        const data = (await response.json()) as { payload: ChatwootConversation[] }
+        return data?.payload ?? []
+    }
+
+    /**
+     * Crea una nueva conversación en Chatwoot.
+     */
+    async createConversation(contactId: number, inboxId: number): Promise<ChatwootConversation> {
+        const response = await fetch(`${this.baseUrl}/conversations`, {
+            method: 'POST',
+            headers: this.headers,
+            body: JSON.stringify({
+                contact_id: contactId,
+                inbox_id: inboxId,
+            }),
+        })
+
+        if (!response.ok) {
+            const error = await response.text()
+            throw new Error(`[Chatwoot] Error creating conversation: ${error}`)
+        }
+
+        return (await response.json()) as ChatwootConversation
+    }
+
+    /**
+     * Envía un mensaje a una conversación de Chatwoot.
+     */
+    async sendMessage(
+        conversationId: number,
+        content: string,
+        messageType: 'incoming' | 'outgoing' = 'incoming'
+    ): Promise<ChatwootMessage> {
+        const response = await fetch(`${this.baseUrl}/conversations/${conversationId}/messages`, {
+            method: 'POST',
+            headers: this.headers,
+            body: JSON.stringify({
+                content,
+                message_type: messageType,
+            }),
+        })
+
+        if (!response.ok) {
+            const error = await response.text()
+            throw new Error(`[Chatwoot] Error sending message: ${error}`)
+        }
+
+        return (await response.json()) as ChatwootMessage
+    }
+}
+
+export { ChatwootApi }

--- a/packages/plugins/chatwoot/src/chatwootApi.ts
+++ b/packages/plugins/chatwoot/src/chatwootApi.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises'
+
 import type {
     ChatwootContact,
     ChatwootConversation,
@@ -7,17 +9,54 @@ import type {
     ChatwootSearchContactsPayload,
 } from './types'
 
+/** Minimal MIME lookup by file extension — avoids external dependencies. */
+const getContentType = (filename: string): string => {
+    const ext = filename.split('.').pop()?.toLowerCase() ?? ''
+    const map: Record<string, string> = {
+        jpg: 'image/jpeg',
+        jpeg: 'image/jpeg',
+        png: 'image/png',
+        gif: 'image/gif',
+        webp: 'image/webp',
+        mp4: 'video/mp4',
+        mp3: 'audio/mpeg',
+        ogg: 'audio/ogg',
+        opus: 'audio/ogg',
+        wav: 'audio/wav',
+        pdf: 'application/pdf',
+        svg: 'image/svg+xml',
+    }
+    return map[ext] ?? 'application/octet-stream'
+}
+
 class ChatwootApi {
     private baseUrl: string
+    private token: string
     private headers: Record<string, string>
-    private accountId: number
 
     constructor(config: ChatwootPluginConfig) {
         this.baseUrl = `${config.url.replace(/\/$/, '')}/api/v1/accounts/${config.accountId}`
-        this.accountId = config.accountId
+        this.token = config.token
         this.headers = {
             'Content-Type': 'application/json',
             api_access_token: config.token,
+        }
+    }
+
+    /**
+     * Verifica que las credenciales sean válidas contra la API de Chatwoot.
+     * Retorna `true` si la cuenta es accesible.
+     */
+    async checkAccount(): Promise<boolean> {
+        try {
+            const response = await fetch(`${this.baseUrl}/`, {
+                method: 'GET',
+                headers: this.headers,
+            })
+            const data = (await response.json()) as { error?: string }
+            return !data?.error
+        } catch {
+            return false
         }
     }
 
@@ -163,12 +202,18 @@ class ChatwootApi {
 
     /**
      * Envía un mensaje a una conversación de Chatwoot.
+     * Si se provee `mediaSource` (URL o ruta local), el mensaje se envía con adjunto via FormData.
      */
     async sendMessage(
         conversationId: number,
         content: string,
-        messageType: 'incoming' | 'outgoing' = 'incoming'
+        messageType: 'incoming' | 'outgoing' = 'incoming',
+        mediaSource?: string | null
     ): Promise<ChatwootMessage> {
+        if (mediaSource) {
+            return this.sendMessageWithMedia(conversationId, content, messageType, mediaSource)
+        }
+
         const response = await fetch(`${this.baseUrl}/conversations/${conversationId}/messages`, {
             method: 'POST',
             headers: this.headers,
@@ -184,6 +229,95 @@ class ChatwootApi {
         }
 
         return (await response.json()) as ChatwootMessage
+    }
+
+    /**
+     * Envía un mensaje con adjunto multimedia a una conversación.
+     * `mediaSource` puede ser una URL https:// o una ruta local en disco.
+     */
+    private async sendMessageWithMedia(
+        conversationId: number,
+        content: string,
+        messageType: 'incoming' | 'outgoing',
+        mediaSource: string
+    ): Promise<ChatwootMessage> {
+        const form = new FormData()
+        form.set('content', content)
+        form.set('message_type', messageType)
+
+        try {
+            const isUrl = mediaSource.startsWith('http://') || mediaSource.startsWith('https://')
+
+            if (isUrl) {
+                const mediaResponse = await fetch(mediaSource)
+                if (mediaResponse.ok) {
+                    const buffer = await mediaResponse.arrayBuffer()
+                    const contentType = mediaResponse.headers.get('content-type') ?? 'application/octet-stream'
+                    const fileName = mediaSource.split('/').pop()?.split('?')[0] ?? 'file'
+                    form.set('attachments[]', new Blob([buffer], { type: contentType }), fileName)
+                }
+            } else {
+                const fileName = mediaSource.split('/').pop() ?? 'file'
+                const fileBuffer = await readFile(mediaSource)
+                const mimeType = getContentType(fileName)
+                form.set('attachments[]', new Blob([new Uint8Array(fileBuffer)], { type: mimeType }), fileName)
+            }
+        } catch (mediaErr) {
+            console.error('[Chatwoot] Could not attach media, sending text-only:', mediaErr)
+        }
+
+        const response = await fetch(`${this.baseUrl}/conversations/${conversationId}/messages`, {
+            method: 'POST',
+            headers: { api_access_token: this.token },
+            body: form,
+        })
+
+        if (!response.ok) {
+            const error = await response.text()
+            throw new Error(`[Chatwoot] Error sending message with media: ${error}`)
+        }
+
+        return (await response.json()) as ChatwootMessage
+    }
+
+    /**
+     * Busca un webhook existente cuya URL contenga `matchUrl`.
+     */
+    async findWebhook(matchUrl: string): Promise<{ id: number; url: string } | null> {
+        try {
+            const response = await fetch(`${this.baseUrl}/webhooks`, {
+                method: 'GET',
+                headers: this.headers,
+            })
+
+            if (!response.ok) return null
+
+            const data = (await response.json()) as { payload?: { webhooks?: Array<{ id: number; url: string }> } }
+            const webhooks = data?.payload?.webhooks ?? []
+            return webhooks.find((w) => w.url === matchUrl) ?? null
+        } catch {
+            return null
+        }
+    }
+
+    /**
+     * Crea un webhook en Chatwoot.
+     */
+    async createWebhook(url: string, subscriptions: string[]): Promise<void> {
+        try {
+            const response = await fetch(`${this.baseUrl}/webhooks`, {
+                method: 'POST',
+                headers: this.headers,
+                body: JSON.stringify({ webhook: { url, subscriptions } }),
+            })
+
+            if (!response.ok) {
+                const error = await response.text()
+                console.error(`[Chatwoot] Error creating webhook: ${error}`)
+            }
+        } catch (err) {
+            console.error('[Chatwoot] Error creating webhook:', err)
+        }
     }
 }
 

--- a/packages/plugins/chatwoot/src/chatwootPlugin.ts
+++ b/packages/plugins/chatwoot/src/chatwootPlugin.ts
@@ -1,0 +1,118 @@
+import type { CoreClass } from '@builderbot/bot'
+
+import { ChatwootApi } from './chatwootApi'
+import type { ChatwootInbox, ChatwootPluginConfig } from './types'
+
+const DEFAULT_INBOX_NAME = 'BuilderBot Inbox'
+
+class ChatwootPlugin {
+    private api: ChatwootApi
+    private config: ChatwootPluginConfig
+    private inbox: ChatwootInbox | null = null
+    private conversationCache = new Map<string, number>()
+    private contactCache = new Map<string, number>()
+
+    constructor(config: ChatwootPluginConfig) {
+        this.config = config
+        this.api = new ChatwootApi(config)
+    }
+
+    /**
+     * Conecta el plugin al bot. Una sola línea y listo.
+     *
+     * ```ts
+     * const bot = await createBot({ flow, provider, database })
+     * await chatwoot.attach(bot)
+     * ```
+     */
+    async attach(bot: CoreClass): Promise<void> {
+        const inboxName = this.config.inboxName ?? DEFAULT_INBOX_NAME
+        this.inbox = await this.api.findOrCreateInbox(inboxName)
+        console.log(`[Chatwoot] Inbox "${this.inbox.name}" ready (id: ${this.inbox.id})`)
+
+        bot.on('send_message', async (payload) => {
+            try {
+                const { from, answer } = payload
+                if (!from || !answer) return
+
+                const content = Array.isArray(answer) ? answer.join('\n') : String(answer)
+                if (!content || content.startsWith('__')) return
+
+                const conversationId = await this.resolveConversation(from)
+                await this.api.sendMessage(conversationId, content, 'outgoing')
+            } catch (err) {
+                console.error('[Chatwoot] Error syncing outgoing message:', err)
+            }
+        })
+
+        bot.provider.on('message', async (payload: { from: string; body: string; name?: string }) => {
+            try {
+                const { from, body, name } = payload
+                if (!from || !body) return
+
+                const conversationId = await this.resolveConversation(from, name)
+                await this.api.sendMessage(conversationId, body, 'incoming')
+            } catch (err) {
+                console.error('[Chatwoot] Error syncing incoming message:', err)
+            }
+        })
+
+        console.log(`[Chatwoot] Plugin attached successfully`)
+    }
+
+    /**
+     * Resuelve (o crea) el contacto y la conversación en Chatwoot para un número dado.
+     */
+    private async resolveConversation(phone: string, name?: string): Promise<number> {
+        const cached = this.conversationCache.get(phone)
+        if (cached) return cached
+
+        let contactId = this.contactCache.get(phone)
+        if (!contactId) {
+            const contact = await this.api.findOrCreateContact(phone, name)
+            if (!contact?.id) throw new Error(`[Chatwoot] Could not resolve contact for ${phone}`)
+            contactId = contact.id
+            this.contactCache.set(phone, contactId)
+        }
+
+        if (!this.inbox) throw new Error('[Chatwoot] Plugin not attached yet. Call attach() first.')
+        const conversation = await this.api.findOrCreateConversation(contactId, this.inbox.id)
+        this.conversationCache.set(phone, conversation.id)
+
+        return conversation.id
+    }
+
+    /**
+     * Acceso directo a la API de Chatwoot para operaciones avanzadas.
+     */
+    getApi(): ChatwootApi {
+        return this.api
+    }
+
+    /**
+     * Retorna el inbox creado por el plugin.
+     */
+    getInbox(): ChatwootInbox | null {
+        return this.inbox
+    }
+}
+
+/**
+ * Crea una instancia del plugin de Chatwoot.
+ *
+ * ```ts
+ * const chatwoot = createChatwootPlugin({
+ *     token: 'tu-token',
+ *     url: 'https://app.chatwoot.com',
+ *     accountId: 1,
+ * })
+ *
+ * const bot = await createBot({ flow, provider, database })
+ * await chatwoot.attach(bot)
+ * ```
+ */
+const createChatwootPlugin = (config: ChatwootPluginConfig): ChatwootPlugin => {
+    return new ChatwootPlugin(config)
+}
+
+export { ChatwootPlugin, createChatwootPlugin }

--- a/packages/plugins/chatwoot/src/chatwootPlugin.ts
+++ b/packages/plugins/chatwoot/src/chatwootPlugin.ts
@@ -1,4 +1,7 @@
 import type { CoreClass } from '@builderbot/bot'
+import { createReadStream } from 'node:fs'
+import { mkdir, unlink } from 'node:fs/promises'
+import { join } from 'node:path'
 
 import { ChatwootApi } from './chatwootApi'
 import type {
@@ -12,6 +15,74 @@ import type {
 
 const DEFAULT_INBOX_NAME = 'BuilderBot Inbox'
 const WEBHOOK_SUBSCRIPTIONS = ['conversation_updated', 'message_created']
+
+/** Maps file extensions to MIME types for correct Content-Type headers when serving media. */
+const MIME_MAP: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    mp4: 'video/mp4',
+    mp3: 'audio/mpeg',
+    ogg: 'audio/ogg',
+    opus: 'audio/ogg',
+    wav: 'audio/wav',
+    pdf: 'application/pdf',
+    svg: 'image/svg+xml',
+}
+
+function mimeFromFilename(filename: string): string {
+    const ext = filename.split('.').pop()?.toLowerCase() ?? ''
+    return MIME_MAP[ext] ?? 'application/octet-stream'
+}
+
+/** Maps WhatsApp `_event_*` body strings to human-readable labels shown in Chatwoot. */
+const EVENT_LABELS: Record<string, string> = {
+    _event_media_: '[image]',
+    _event_voice_note_: '[audio]',
+    _event_document_: '[file]',
+    _event_location_: '[location]',
+    _event_video_: '[video]',
+    _event_sticker_: '[sticker]',
+    _event_order_: '[order]',
+}
+
+/**
+ * Converts a WhatsApp provider event string (e.g. `_event_media_`) into a readable label.
+ * Returns the original string unchanged for normal text messages.
+ */
+function normalizeBody(raw: string): string {
+    for (const [key, label] of Object.entries(EVENT_LABELS)) {
+        if (raw.includes(key)) return label
+    }
+    return raw
+}
+
+/** Returns true if the body string corresponds to a WhatsApp media event. */
+function isMediaEvent(raw: string): boolean {
+    return Object.keys(EVENT_LABELS).some((key) => raw.includes(key))
+}
+
+/**
+ * Extracts the real caption from the raw provider message context (e.g. Baileys WAMessage).
+ * Baileys always overwrites `body` with `_event_media_` for media messages, but the original
+ * caption typed by the user is preserved in `message.imageMessage.caption` (and equivalent
+ * fields for video, document, sticker, etc.).
+ * Returns the caption string if present and non-empty, otherwise null.
+ */
+function extractCaption(payload: BotIncomingMessagePayload): string | null {
+    const msg = (payload as any).message
+    if (!msg) return null
+    const caption =
+        msg.imageMessage?.caption ||
+        msg.videoMessage?.caption ||
+        msg.documentMessage?.caption ||
+        msg.documentWithCaptionMessage?.message?.documentMessage?.caption ||
+        msg.extendedTextMessage?.text ||
+        null
+    return typeof caption === 'string' && caption.trim() ? caption.trim() : null
+}
 
 /**
  * Minimal single-concurrency async queue.
@@ -36,6 +107,9 @@ class SimpleQueue {
     }
 }
 
+const MEDIA_ROUTE = '/media'
+const MEDIA_DIR_NAME = join('tmp', 'chatwoot-media')
+
 class ChatwootPlugin {
     private api: ChatwootApi
     private config: ChatwootPluginConfig
@@ -43,6 +117,8 @@ class ChatwootPlugin {
     private conversationCache = new Map<string, number>()
     private contactCache = new Map<string, number>()
     private messageQueue = new SimpleQueue()
+    private mediaDir: string | null = null
+    private mediaBaseUrl: string | null = null
 
     /** False if Chatwoot credentials are invalid or unreachable. All operations are skipped when false. */
     public status = true
@@ -72,6 +148,8 @@ class ChatwootPlugin {
         this.inbox = await this.api.findOrCreateInbox(inboxName)
         console.log(`[Chatwoot] Inbox "${this.inbox.name}" ready (id: ${this.inbox.id})`)
 
+        const server = (bot as any).provider?.server
+
         if (this.config.webhookUrl) {
             const existing = await this.api.findWebhook(this.config.webhookUrl)
             if (!existing) {
@@ -79,6 +157,59 @@ class ChatwootPlugin {
                 console.log(`[Chatwoot] Webhook registered: ${this.config.webhookUrl}`)
             } else {
                 console.log(`[Chatwoot] Webhook already exists (id: ${existing.id})`)
+            }
+
+            const urlPath = new URL(this.config.webhookUrl).pathname
+            if (server?.post) {
+                server.post(urlPath, (req: any, res: any) => {
+                    res.writeHead(200, { 'Content-Type': 'application/json' })
+                    res.end(JSON.stringify({ status: 'ok' }))
+
+                    const botRef = bot as CoreClass & ChatwootBotRef
+                    if (typeof (botRef as any).sendMessage !== 'function') {
+                        ;(botRef as any).sendMessage = (phone: string, msg: string, opts?: any) =>
+                            (bot as any).provider?.sendMessage(phone, msg, opts)
+                    }
+                    if (!(botRef as any).blacklist) {
+                        ;(botRef as any).blacklist = (bot as any).dynamicBlacklist
+                    }
+
+                    this.handleWebhook(botRef, req.body ?? {}).catch((err) =>
+                        console.error('[Chatwoot] Webhook processing error:', err)
+                    )
+                })
+                console.log(`[Chatwoot] Webhook route auto-registered at ${urlPath}`)
+            } else {
+                console.warn('[Chatwoot] provider.server not available — register the webhook route manually')
+            }
+
+            // Register a public GET route to serve media files downloaded from WhatsApp.
+            // Files are stored in tmp/chatwoot-media/ and exposed at /media/:filename
+            // so Chatwoot can download them by URL rather than receiving a binary upload.
+            if (server?.get) {
+                this.mediaDir = join(process.cwd(), MEDIA_DIR_NAME)
+                this.mediaBaseUrl = new URL(this.config.webhookUrl).origin
+                await mkdir(this.mediaDir, { recursive: true })
+
+                server.get(`${MEDIA_ROUTE}/:filename`, (req: any, res: any) => {
+                    const raw = req.params?.filename ?? ''
+                    const safeName = raw.replace(/[^a-zA-Z0-9._-]/g, '')
+                    if (!safeName) {
+                        res.writeHead(400)
+                        res.end('Bad request')
+                        return
+                    }
+                    const filePath = join(this.mediaDir!, safeName)
+                    const contentType = mimeFromFilename(safeName)
+                    const stream = createReadStream(filePath)
+                    stream.on('error', () => {
+                        res.writeHead(404)
+                        res.end('Not found')
+                    })
+                    res.writeHead(200, { 'Content-Type': contentType })
+                    stream.pipe(res)
+                })
+                console.log(`[Chatwoot] Media route registered at ${MEDIA_ROUTE}/:filename`)
             }
         }
 
@@ -88,13 +219,16 @@ class ChatwootPlugin {
 
             this.messageQueue.enqueue(async () => {
                 const { from, answer } = payload
-                if (!from || !answer) return
+                if (!from) return
 
-                const content = Array.isArray(answer) ? answer.join('\n') : String(answer)
-                if (!content || content.startsWith('__')) return
+                const rawContent = Array.isArray(answer) ? answer.join('\n') : String(answer ?? '')
+                if (rawContent.startsWith('__')) return
+
+                const mediaUrl = (payload as unknown as BotOutgoingPayload).options?.media ?? null
+                const content = normalizeBody(rawContent)
+                if (!content && !mediaUrl) return
 
                 const conversationId = await this.resolveConversation(from)
-                const mediaUrl = (payload as unknown as BotOutgoingPayload).options?.media ?? null
                 await this.api.sendMessage(conversationId, content, 'outgoing', mediaUrl)
             })
         })
@@ -105,11 +239,52 @@ class ChatwootPlugin {
 
             this.messageQueue.enqueue(async () => {
                 const { from, body, name } = payload
-                if (!from || !body) return
+                if (!from) return
 
+                let mediaUrl: string | null = payload.options?.media ?? null
+                let tempFilePath: string | null = null
+
+                // Fallback for providers (e.g. Baileys) that carry the raw WAMessage context
+                // but do not populate options.media. Download the file via provider.saveFile,
+                // save it to the public media directory and expose it as an HTTP asset so
+                // Chatwoot can fetch and store it by URL.
+                if (!mediaUrl && body && isMediaEvent(body)) {
+                    const saveFile = (bot as any).provider?.saveFile
+                    if (typeof saveFile === 'function') {
+                        try {
+                            if (this.mediaDir && this.mediaBaseUrl) {
+                                tempFilePath = await saveFile.call((bot as any).provider, payload, {
+                                    path: this.mediaDir,
+                                })
+                                const filename = tempFilePath!.split('/').pop()
+                                mediaUrl = `${this.mediaBaseUrl}${MEDIA_ROUTE}/${filename}`
+                            } else {
+                                tempFilePath = await saveFile.call((bot as any).provider, payload)
+                                mediaUrl = tempFilePath
+                            }
+                        } catch (err) {
+                            console.error('[Chatwoot] Could not download media via saveFile:', err)
+                        }
+                    }
+                }
+
+                if (!body && !mediaUrl) return
+
+                // Prefer the real caption from the raw message context over the normalised label.
+                // When a user sends an image with text Baileys sets body to _event_media_ and
+                // stores the actual caption inside message.imageMessage.caption (and similar).
+                // If there is a media attachment but no caption, send empty content so Chatwoot
+                // shows just the image/file preview without a redundant [image] label.
+                // Only fall back to the event label when there is no media file at all
+                // (e.g. location, sticker, order — events that have no downloadable attachment).
+                const caption = extractCaption(payload)
+                const content = caption ?? (mediaUrl ? '' : normalizeBody(body ?? ''))
                 const conversationId = await this.resolveConversation(from, name)
-                const mediaUrl = payload.options?.media ?? null
-                await this.api.sendMessage(conversationId, body, 'incoming', mediaUrl)
+                await this.api.sendMessage(conversationId, content, 'incoming', mediaUrl)
+
+                if (tempFilePath) {
+                    unlink(tempFilePath).catch(() => undefined)
+                }
             })
         })
 
@@ -163,10 +338,17 @@ class ChatwootPlugin {
         ) {
             const phone = body?.conversation?.meta?.sender?.phone_number?.replace('+', '')
             const content = body?.content ?? ''
-            const file = body?.attachments?.length ? body.attachments[0] : null
+            const attachments = body?.attachments ?? []
 
-            if (phone) {
-                await bot.sendMessage(phone, content, { media: file?.data_url ?? null })
+            if (phone && (content || attachments.length)) {
+                const firstMedia = attachments[0]?.data_url ?? null
+                await bot.sendMessage(phone, content, { media: firstMedia })
+
+                for (const attachment of attachments.slice(1)) {
+                    if (attachment.data_url) {
+                        await bot.sendMessage(phone, '', { media: attachment.data_url })
+                    }
+                }
             }
         }
     }

--- a/packages/plugins/chatwoot/src/chatwootPlugin.ts
+++ b/packages/plugins/chatwoot/src/chatwootPlugin.ts
@@ -1,9 +1,40 @@
 import type { CoreClass } from '@builderbot/bot'
 
 import { ChatwootApi } from './chatwootApi'
-import type { ChatwootInbox, ChatwootPluginConfig } from './types'
+import type {
+    BotIncomingMessagePayload,
+    BotOutgoingPayload,
+    ChatwootBotRef,
+    ChatwootInbox,
+    ChatwootPluginConfig,
+    ChatwootWebhookBody,
+} from './types'
 
 const DEFAULT_INBOX_NAME = 'BuilderBot Inbox'
+const WEBHOOK_SUBSCRIPTIONS = ['conversation_updated', 'message_created']
+
+/**
+ * Minimal single-concurrency async queue.
+ * Ensures Chatwoot API calls are serialized to avoid race conditions.
+ */
+class SimpleQueue {
+    private running = false
+    private tasks: Array<() => Promise<void>> = []
+
+    enqueue(task: () => Promise<void>): void {
+        this.tasks.push(task)
+        if (!this.running) this.drain()
+    }
+
+    private async drain(): Promise<void> {
+        this.running = true
+        while (this.tasks.length > 0) {
+            const task = this.tasks.shift()!
+            await task().catch((err) => console.error('[Chatwoot] Queue task error:', err))
+        }
+        this.running = false
+    }
+}
 
 class ChatwootPlugin {
     private api: ChatwootApi
@@ -11,6 +42,10 @@ class ChatwootPlugin {
     private inbox: ChatwootInbox | null = null
     private conversationCache = new Map<string, number>()
     private contactCache = new Map<string, number>()
+    private messageQueue = new SimpleQueue()
+
+    /** False if Chatwoot credentials are invalid or unreachable. All operations are skipped when false. */
+    public status = true
 
     constructor(config: ChatwootPluginConfig) {
         this.config = config
@@ -26,12 +61,32 @@ class ChatwootPlugin {
      * ```
      */
     async attach(bot: CoreClass): Promise<void> {
+        const accountOk = await this.api.checkAccount()
+        if (!accountOk) {
+            console.error('[Chatwoot] Invalid credentials or unreachable endpoint. Plugin disabled.')
+            this.status = false
+            return
+        }
+
         const inboxName = this.config.inboxName ?? DEFAULT_INBOX_NAME
         this.inbox = await this.api.findOrCreateInbox(inboxName)
         console.log(`[Chatwoot] Inbox "${this.inbox.name}" ready (id: ${this.inbox.id})`)
 
+        if (this.config.webhookUrl) {
+            const existing = await this.api.findWebhook(this.config.webhookUrl)
+            if (!existing) {
+                await this.api.createWebhook(this.config.webhookUrl, WEBHOOK_SUBSCRIPTIONS)
+                console.log(`[Chatwoot] Webhook registered: ${this.config.webhookUrl}`)
+            } else {
+                console.log(`[Chatwoot] Webhook already exists (id: ${existing.id})`)
+            }
+        }
+
         bot.on('send_message', async (payload) => {
-            try {
+            if (!this.status) return
+            if (payload.from?.includes('@g.us')) return
+
+            this.messageQueue.enqueue(async () => {
                 const { from, answer } = payload
                 if (!from || !answer) return
 
@@ -39,25 +94,81 @@ class ChatwootPlugin {
                 if (!content || content.startsWith('__')) return
 
                 const conversationId = await this.resolveConversation(from)
-                await this.api.sendMessage(conversationId, content, 'outgoing')
-            } catch (err) {
-                console.error('[Chatwoot] Error syncing outgoing message:', err)
-            }
+                const mediaUrl = (payload as unknown as BotOutgoingPayload).options?.media ?? null
+                await this.api.sendMessage(conversationId, content, 'outgoing', mediaUrl)
+            })
         })
 
-        bot.provider.on('message', async (payload: { from: string; body: string; name?: string }) => {
-            try {
+        bot.provider.on('message', async (payload: BotIncomingMessagePayload) => {
+            if (!this.status) return
+            if (payload.from?.includes('@g.us')) return
+
+            this.messageQueue.enqueue(async () => {
                 const { from, body, name } = payload
                 if (!from || !body) return
 
                 const conversationId = await this.resolveConversation(from, name)
-                await this.api.sendMessage(conversationId, body, 'incoming')
-            } catch (err) {
-                console.error('[Chatwoot] Error syncing incoming message:', err)
-            }
+                const mediaUrl = payload.options?.media ?? null
+                await this.api.sendMessage(conversationId, body, 'incoming', mediaUrl)
+            })
         })
 
-        console.log(`[Chatwoot] Plugin attached successfully`)
+        console.log('[Chatwoot] Plugin attached successfully')
+    }
+
+    /**
+     * Procesa un webhook entrante desde Chatwoot.
+     *
+     * Wire this to your HTTP route handler:
+     * ```ts
+     * server.post('/v1/chatwoot', handleCtx(async (bot, req, res) => {
+     *     await chatwoot.handleWebhook(bot, req.body)
+     *     res.end(JSON.stringify({ status: 'ok' }))
+     * }))
+     * ```
+     *
+     * Handles:
+     * - `conversation_updated` + assignee change → add/remove phone from blacklist
+     * - `message_created` outgoing on API channel → forward message to WhatsApp
+     */
+    async handleWebhook(bot: CoreClass & ChatwootBotRef, body: ChatwootWebhookBody): Promise<void> {
+        if (!this.inbox) return
+
+        const inboxIdFromBody =
+            body?.conversation?.inbox_id ?? body?.inbox?.id ?? body?.conversation?.contact_inbox?.inbox_id
+
+        if (inboxIdFromBody !== undefined && inboxIdFromBody !== this.inbox.id) return
+
+        const changedKeys = body?.changed_attributes?.flatMap((attr) => Object.keys(attr)) ?? []
+
+        if (body?.event === 'conversation_updated' && changedKeys.includes('assignee_id')) {
+            const phone = body?.meta?.sender?.phone_number?.replace('+', '')
+            const idAssigned = (body?.changed_attributes?.[0] as any)?.assignee_id?.current_value ?? null
+
+            if (phone) {
+                if (idAssigned) {
+                    bot.blacklist?.add(phone)
+                } else if (bot.blacklist?.checkIf(phone)) {
+                    bot.blacklist?.remove(phone)
+                }
+            }
+            return
+        }
+
+        if (
+            body?.private === false &&
+            body?.event === 'message_created' &&
+            body?.message_type === 'outgoing' &&
+            body?.conversation?.channel?.includes('Channel::Api')
+        ) {
+            const phone = body?.conversation?.meta?.sender?.phone_number?.replace('+', '')
+            const content = body?.content ?? ''
+            const file = body?.attachments?.length ? body.attachments[0] : null
+
+            if (phone) {
+                await bot.sendMessage(phone, content, { media: file?.data_url ?? null })
+            }
+        }
     }
 
     /**
@@ -71,7 +182,7 @@ class ChatwootPlugin {
         if (!contactId) {
             const contact = await this.api.findOrCreateContact(phone, name)
             if (!contact?.id) throw new Error(`[Chatwoot] Could not resolve contact for ${phone}`)
-            contactId = contact.id
+            contactId = contact.id!
             this.contactCache.set(phone, contactId)
         }
 
@@ -105,6 +216,7 @@ class ChatwootPlugin {
  *     token: 'tu-token',
  *     url: 'https://app.chatwoot.com',
  *     accountId: 1,
+ *     webhookUrl: 'https://mi-bot.example.com/v1/chatwoot',
  * })
  *
  * const bot = await createBot({ flow, provider, database })

--- a/packages/plugins/chatwoot/src/index.ts
+++ b/packages/plugins/chatwoot/src/index.ts
@@ -1,0 +1,3 @@
+export { ChatwootPlugin, createChatwootPlugin } from './chatwootPlugin'
+export { ChatwootApi } from './chatwootApi'
+export * from './types'

--- a/packages/plugins/chatwoot/src/types.ts
+++ b/packages/plugins/chatwoot/src/types.ts
@@ -60,6 +60,20 @@ export interface BotIncomingMessagePayload {
     body: string
     name?: string
     options?: { media?: string }
+    /**
+     * Raw provider-specific message context. Baileys spreads the full WAMessage
+     * here, which is needed by `provider.saveFile` to download media when
+     * `options.media` is not populated.
+     */
+    [key: string]: unknown
+}
+
+/**
+ * Duck-typed interface for providers that can download incoming media to disk.
+ * Baileys exposes this as `provider.saveFile(ctx)` returning a local file path.
+ */
+export interface BotProviderWithSaveFile {
+    saveFile(ctx: BotIncomingMessagePayload, options?: { path?: string }): Promise<string>
 }
 
 /**

--- a/packages/plugins/chatwoot/src/types.ts
+++ b/packages/plugins/chatwoot/src/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Configuración principal del plugin de Chatwoot.
+ * Solo necesitas `token`, `url` y `accountId` para empezar.
+ */
+export interface ChatwootPluginConfig {
+    /** API access token de Chatwoot (User o Agent token) */
+    token: string
+    /** URL base de tu instancia de Chatwoot (ej: https://app.chatwoot.com) */
+    url: string
+    /** ID de la cuenta en Chatwoot */
+    accountId: number
+    /** Nombre del inbox que se creará automáticamente (default: 'BuilderBot Inbox') */
+    inboxName?: string
+}
+
+export interface ChatwootContact {
+    id?: number
+    name?: string
+    phone_number?: string
+    email?: string
+    identifier?: string
+}
+
+export interface ChatwootConversation {
+    id: number
+    inbox_id: number
+    contact_id: number
+    status?: string
+    account_id?: number
+}
+
+export interface ChatwootInbox {
+    id: number
+    name: string
+    channel_type?: string
+    webhook_url?: string
+}
+
+export interface ChatwootMessage {
+    id?: number
+    content: string
+    message_type: 'incoming' | 'outgoing'
+    content_type?: string
+    private?: boolean
+}
+
+export interface ChatwootApiResponse<T = unknown> {
+    success: boolean
+    data?: T
+    error?: string
+}
+
+export interface ChatwootSearchContactsPayload {
+    payload: ChatwootContact[]
+}
+
+export interface ChatwootConversationsPayload {
+    data: {
+        payload: ChatwootConversation[]
+    }
+}

--- a/packages/plugins/chatwoot/src/types.ts
+++ b/packages/plugins/chatwoot/src/types.ts
@@ -11,6 +11,12 @@ export interface ChatwootPluginConfig {
     accountId: number
     /** Nombre del inbox que se creará automáticamente (default: 'BuilderBot Inbox') */
     inboxName?: string
+    /**
+     * URL pública donde Chatwoot enviará webhooks hacia el bot.
+     * Si se provee, el plugin registrará (o reutilizará) el webhook automáticamente.
+     * Ej: 'https://mi-bot.example.com/v1/chatwoot'
+     */
+    webhookUrl?: string
 }
 
 export interface ChatwootContact {
@@ -19,6 +25,7 @@ export interface ChatwootContact {
     phone_number?: string
     email?: string
     identifier?: string
+    contact_inboxes?: Array<{ inbox: { id: number } }>
 }
 
 export interface ChatwootConversation {
@@ -44,18 +51,65 @@ export interface ChatwootMessage {
     private?: boolean
 }
 
-export interface ChatwootApiResponse<T = unknown> {
-    success: boolean
-    data?: T
-    error?: string
-}
-
 export interface ChatwootSearchContactsPayload {
     payload: ChatwootContact[]
 }
 
-export interface ChatwootConversationsPayload {
-    data: {
-        payload: ChatwootConversation[]
+export interface BotIncomingMessagePayload {
+    from: string
+    body: string
+    name?: string
+    options?: { media?: string }
+}
+
+/**
+ * Duck-typed interface for the bot fields used by handleWebhook.
+ * Combine with CoreClass: `bot: CoreClass & ChatwootBotRef`.
+ */
+export interface ChatwootBotRef {
+    blacklist?: {
+        add(phone: string): void
+        remove(phone: string): void
+        checkIf(phone: string): boolean
     }
+    sendMessage(number: string, message: string, options?: { media?: string | null }): Promise<unknown>
+}
+
+/**
+ * Minimal shape of the send_message event payload for accessing options.media.
+ * The full payload is inferred from HostEventTypes; this covers only what the plugin needs.
+ */
+export interface BotOutgoingPayload {
+    from?: string
+    answer?: string | string[]
+    options?: { media?: string | null }
+}
+
+/** Shape of the webhook body that Chatwoot POSTs to the bot */
+export interface ChatwootWebhookBody {
+    event?: string
+    message_type?: string
+    private?: boolean
+    content?: string
+    attachments?: Array<{ data_url?: string; [key: string]: unknown }>
+    changed_attributes?: Array<Record<string, unknown>>
+    meta?: {
+        sender?: { phone_number?: string; name?: string }
+        assignee?: { id?: number } | null
+    }
+    conversation?: {
+        id?: number
+        inbox_id?: number
+        channel?: string
+        status?: string
+        meta?: {
+            sender?: { phone_number?: string; name?: string }
+            assignee?: { id?: number } | null
+        }
+        contact_inbox?: { inbox_id?: number }
+        messages?: Array<{ inbox_id?: number }>
+    }
+    inbox?: { id?: number }
+    sender?: { phone_number?: string; type?: string }
+    account?: { id?: number }
 }

--- a/packages/plugins/chatwoot/tsconfig.json
+++ b/packages/plugins/chatwoot/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "declaration": true,
+        "declarationMap": true,
+        "moduleResolution": "node",
+        "importHelpers": true,
+        "target": "es2021",
+        "types": ["node"]
+    },
+    "include": ["src/**/*.js", "src/**/*.ts"],
+    "exclude": ["**/*.spec.ts", "**/*.test.ts", "node_modules"]
+}

--- a/packages/plugins/chatwoot/tsconfig.json
+++ b/packages/plugins/chatwoot/tsconfig.json
@@ -7,6 +7,7 @@
         "rootDir": "./src",
         "declaration": true,
         "declarationMap": true,
+        "module": "ES2020",
         "moduleResolution": "node",
         "importHelpers": true,
         "target": "es2021",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -615,6 +615,34 @@ importers:
                 specifier: ^0.5.6
                 version: 0.5.6
 
+    packages/plugins/chatwoot:
+        dependencies:
+            '@builderbot/bot':
+                specifier: ^1.3.15-alpha.21
+                version: 1.3.15
+        devDependencies:
+            '@rollup/plugin-commonjs':
+                specifier: ^29.0.0
+                version: 29.0.0(rollup@4.53.3)
+            '@rollup/plugin-node-resolve':
+                specifier: ^16.0.3
+                version: 16.0.3(rollup@4.53.3)
+            '@types/node':
+                specifier: ^24.10.2
+                version: 24.10.2
+            rimraf:
+                specifier: ^6.1.2
+                version: 6.1.2
+            rollup-plugin-typescript2:
+                specifier: ^0.36.0
+                version: 0.36.0(rollup@4.53.3)(typescript@5.9.3)
+            tslib:
+                specifier: ^2.8.1
+                version: 2.8.1
+            tsm:
+                specifier: ^2.3.0
+                version: 2.3.0
+
     packages/provider-baileys:
         dependencies:
             '@adiwajshing/keyed-db':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
     - 'packages/*'
+    - 'packages/plugins/*'


### PR DESCRIPTION
Introduces a new plugin category (packages/plugins/) and the first plugin: @builderbot/plugin-chatwoot.
The plugin automatically creates inboxes, saves contacts, and syncs conversations with Chatwoot
using a simple DX: createChatwootPlugin({ token, url, accountId }) + chatwoot.attach(bot).

https://claude.ai/code/session_01KYzSLXHCUPi1G8rR6GDcKm