### PR TITLE
fix(provider-baileys): fallback @lid JID when remoteJidAlt is absent …

### DIFF
--- a/packages/provider-baileys/__tests__/baileysProvider.test.ts
+++ b/packages/provider-baileys/__tests__/baileysProvider.test.ts
@@ -1002,6 +1002,57 @@ describe('#BaileysProvider', () => {
             expect(provider.emit).toHaveBeenCalled()
         })
 
+        test('Detect orderMessage with standard JID', async () => {
+            // Arrange
+            jest.mocked(utils.generateRefProvider).mockReturnValue('_event_order___mock-uuid')
+
+            const mockMessage = {
+                message: {
+                    orderMessage: { orderId: 'order-123', token: 'token-abc' },
+                },
+                pushName: 'Buyer Name',
+                key: {
+                    remoteJid: '5491112223344@s.whatsapp.net',
+                    id: 'msg-order-001',
+                },
+            }
+
+            // Act
+            await provider['busEvents']()[0].func({ messages: [mockMessage], type: 'notify' })
+
+            // Assert
+            expect(provider.emit).toHaveBeenCalledWith(
+                'message',
+                expect.objectContaining({ body: '_event_order___mock-uuid' })
+            )
+        })
+
+        test('Detect orderMessage with @lid JID and no remoteJidAlt', async () => {
+            // Arrange — escenario del bug: @lid sin remoteJidAlt crasheaba baileyCleanNumber(undefined)
+            jest.mocked(utils.generateRefProvider).mockReturnValue('_event_order___mock-uuid')
+
+            const mockMessage = {
+                message: {
+                    orderMessage: { orderId: 'order-456', token: 'token-xyz' },
+                },
+                pushName: 'Buyer Name',
+                key: {
+                    remoteJid: '5491112223344@lid',
+                    remoteJidAlt: undefined,
+                    id: 'msg-order-002',
+                },
+            }
+
+            // Act
+            await provider['busEvents']()[0].func({ messages: [mockMessage], type: 'notify' })
+
+            // Assert
+            expect(provider.emit).toHaveBeenCalledWith(
+                'message',
+                expect.objectContaining({ body: '_event_order___mock-uuid' })
+            )
+        })
+
         test('Detect broadcast in a message', async () => {
             // Arrange
             const mockMessage = {

--- a/packages/provider-baileys/src/bailey.ts
+++ b/packages/provider-baileys/src/bailey.ts
@@ -587,9 +587,10 @@ class BaileysProvider extends ProviderClass<WASocket> {
                         }
                     }
 
-                    // Preferir @s.whatsapp.net (remoteJidAlt) sobre @lid cuando esté disponible
-                    const { remoteJid, remoteJidAlt } = (messageCtx?.key ?? {}) as any
-                    const fromParse = remoteJid?.includes('@lid') ? remoteJidAlt || remoteJid : remoteJid
+                    // Buscar siempre el que tenga formato @s.whatsapp.net (puede estar en remoteJid o remoteJidAlt)
+                    const remoteJid = (messageCtx?.key as any)?.remoteJid
+                    const remoteJidAlt = (messageCtx?.key as any)?.remoteJidAlt
+                    const fromParse = remoteJid?.includes('@lid') ? remoteJidAlt || remoteJid?.split('@')[0] : remoteJid
 
                     let payload = {
                         ...messageCtx,


### PR DESCRIPTION
…on orderMessage

# Que tipo de Pull Request es?

- [ ] Mejoras
- [x ] Bug
- [ ] Docs / tests

# Descripción 

  Fix de crash al recibir un `orderMessage` cuando el `remoteJid` tiene formato `@lid` y `remoteJidAlt` es `undefined`.

  **Causa del bug:** Al detectar un mensaje de orden con JID tipo `@lid`, el código intentaba usar `remoteJidAlt` para obtener el número
   limpio. Si `remoteJidAlt` no estaba presente, se llamaba `baileyCleanNumber(undefined)` y crasheaba.

  **Fix:** Se agrega un fallback que extrae el número directamente del `remoteJid` cuando `remoteJidAlt` está ausente:

  ```ts
  // Antes
  const fromParse = remoteJid?.includes('@lid') ? remoteJidAlt : remoteJid

  // Después
  const fromParse = remoteJid?.includes('@lid') ? remoteJidAlt || remoteJid?.split('@')[0] : remoteJid

  Tests agregados:
  - orderMessage con JID estándar (@s.whatsapp.net) — caso normal
  - orderMessage con JID @lid sin remoteJidAlt — caso del bug


> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
