### PR TITLE
test(provider-baileys,provider-sherpa): enable skipped sendPoll unit …

### DIFF
--- a/packages/provider-baileys/__tests__/baileysProvider.test.ts
+++ b/packages/provider-baileys/__tests__/baileysProvider.test.ts
@@ -536,8 +536,8 @@ describe('#BaileysProvider', () => {
         })
     })
 
-    describe.skip('#sendPoll', () => {
-        test('should send poll message with correct options', async () => {
+    describe('#sendPoll', () => {
+        test('should send poll message with multiselect false (selectableCount 0)', async () => {
             // Arrange
             const numberIn = phoneNumber
             const text = 'Please vote'
@@ -554,10 +554,12 @@ describe('#BaileysProvider', () => {
 
             // Assert
             expect(result).toEqual('success')
-            expect(mockSendMessage).toHaveBeenCalled()
+            expect(mockSendMessage).toHaveBeenCalledWith(phoneNumber, {
+                poll: { name: text, values: poll.options, selectableCount: 0 },
+            })
         })
 
-        test('should send poll message with correct options multiselect undefined', async () => {
+        test('should send poll message with multiselect undefined (selectableCount 1)', async () => {
             // Arrange
             const numberIn = phoneNumber
             const text = 'Please vote'
@@ -574,10 +576,12 @@ describe('#BaileysProvider', () => {
 
             // Assert
             expect(result).toEqual('success')
-            expect(mockSendMessage).toHaveBeenCalled()
+            expect(mockSendMessage).toHaveBeenCalledWith(phoneNumber, {
+                poll: { name: text, values: poll.options, selectableCount: 1 },
+            })
         })
 
-        test('should send poll message with correct options multiselect true', async () => {
+        test('should send poll message with multiselect true (selectableCount 1)', async () => {
             // Arrange
             const numberIn = phoneNumber
             const text = 'Please vote'
@@ -587,14 +591,16 @@ describe('#BaileysProvider', () => {
             }
 
             const mockSendMessage = mockSendSuccess
-            provider.vendor.sendMessage = mockSendSuccess
+            provider.vendor.sendMessage = mockSendMessage
 
             // Act
             const result = await provider.sendPoll(numberIn, text, poll)
 
             // Assert
             expect(result).toEqual('success')
-            expect(mockSendMessage).toHaveBeenCalled()
+            expect(mockSendMessage).toHaveBeenCalledWith(phoneNumber, {
+                poll: { name: text, values: poll.options, selectableCount: 1 },
+            })
         })
 
         test('should return false if options length is less than 2', async () => {

--- a/packages/provider-sherpa/__tests__/sherpaProvider.test.ts
+++ b/packages/provider-sherpa/__tests__/sherpaProvider.test.ts
@@ -538,81 +538,59 @@ describe('#SherpaProvider', () => {
         })
     })
 
-    describe.skip('#sendPoll', () => {
-        test('should send poll message with correct options', async () => {
+    describe('#sendPoll', () => {
+        test('should return false and emit notice event (not available in whaileys)', async () => {
             // Arrange
-            const numberIn = phoneNumber
-            const text = 'Please vote'
-            const poll = {
+            const mockEmit = jest.fn()
+            provider.emit = mockEmit
+
+            // Act
+            const result = await provider.sendPoll(phoneNumber, 'Please vote', {
                 options: ['Option 1', 'Option 2', 'Option 3'],
                 multiselect: false,
-            }
-
-            const mockSendMessage = mockSendSuccess
-            provider.vendor.sendMessage = mockSendMessage
-
-            // Act
-            const result = await provider.sendPoll(numberIn, text, poll)
+            })
 
             // Assert
-            expect(result).toEqual('success')
-            expect(mockSendMessage).toHaveBeenCalled()
+            expect(result).toBe(false)
+            expect(mockEmit).toHaveBeenCalledWith('notice', {
+                title: 'METHOD NOT AVAILABLE',
+                instructions: [
+                    'sendPoll is not available with whaileys provider',
+                    'This feature is only available with baileys provider',
+                ],
+            })
         })
 
-        test('should send poll message with correct options multiselect undefined', async () => {
+        test('should always return false regardless of options count', async () => {
             // Arrange
-            const numberIn = phoneNumber
-            const text = 'Please vote'
-            const poll = {
-                options: ['Option 1', 'Option 2', 'Option 3'],
-                multiselect: undefined,
-            }
-
-            const mockSendMessage = mockSendSuccess
-            provider.vendor.sendMessage = mockSendMessage
+            const mockEmit = jest.fn()
+            provider.emit = mockEmit
 
             // Act
-            const result = await provider.sendPoll(numberIn, text, poll)
+            const result = await provider.sendPoll(phoneNumber, 'Please vote', {
+                options: ['Only one'],
+                multiselect: false,
+            })
 
             // Assert
-            expect(result).toEqual('success')
-            expect(mockSendMessage).toHaveBeenCalled()
+            expect(result).toBe(false)
+            expect(mockEmit).toHaveBeenCalled()
         })
 
-        test('should send poll message with correct options multiselect true', async () => {
+        test('should always return false regardless of multiselect value', async () => {
             // Arrange
-            const numberIn = phoneNumber
-            const text = 'Please vote'
-            const poll = {
-                options: ['Option 1', 'Option 2', 'Option 3'],
+            const mockEmit = jest.fn()
+            provider.emit = mockEmit
+
+            // Act
+            const result = await provider.sendPoll(phoneNumber, 'Please vote', {
+                options: ['Option 1', 'Option 2'],
                 multiselect: true,
-            }
-
-            const mockSendMessage = mockSendSuccess
-            provider.vendor.sendMessage = mockSendSuccess
-
-            // Act
-            const result = await provider.sendPoll(numberIn, text, poll)
+            })
 
             // Assert
-            expect(result).toEqual('success')
-            expect(mockSendMessage).toHaveBeenCalled()
-        })
-
-        test('should return false if options length is less than 2', async () => {
-            // Arrange
-            const numberIn = phoneNumber
-            const text = 'Please vote'
-            const poll = {
-                options: ['Option 1'],
-                multiselect: false,
-            }
-
-            // Act
-            const result = await provider.sendPoll(numberIn, text, poll)
-
-            // Assert
-            expect(result).toBeFalsy()
+            expect(result).toBe(false)
+            expect(mockEmit).toHaveBeenCalled()
         })
     })
 


### PR DESCRIPTION
Enable previously skipped describe.skip('#sendPoll') test suites in both provider-baileys and provider-sherpa.

For provider-baileys: sendPoll is fully implemented; tests now assert the exact poll payload passed to vendor.sendMessage, verifying selectableCount values for each multiselect variant (false→0, undefined→1, true→1).

For provider-sherpa: sendPoll is deprecated and always returns false; tests are rewritten to verify the 'notice' event is emitted with the correct METHOD NOT AVAILABLE payload.

# Que tipo de Pull Request es?

- [ ] Mejoras
- [ ] Bug
- [x] Docs / tests

# Descripción
Enable the two `describe.skip('#sendPoll')` test suites that were previously skipped.

- **provider-baileys**: 4 tests verify the exact poll payload (`name`, `values`, `selectableCount`) sent to `vendor.sendMessage` for each `multiselect` variant.
- **provider-sherpa**: 3 tests verify that the deprecated `sendPoll` always returns `false` and emits a `notice` event with `METHOD NOT AVAILABLE`.

All tests pass with `pnpm run test`.

> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
