### PR TITLE
fix(provider-instagram): pass correct attachment type for

### DIFF
--- a/packages/provider-instagram/__tests__/instagram.provider.spec.ts
+++ b/packages/provider-instagram/__tests__/instagram.provider.spec.ts
@@ -376,6 +376,14 @@ describe('InstagramProvider', () => {
             const result = await provider.sendMedia('user123', '', 'https://example.com/video.mp4')
 
             expect(result).toEqual({ message_id: 'msg_123' })
+            expect(axios.post).toHaveBeenLastCalledWith(
+                expect.stringContaining('/messages'),
+                expect.objectContaining({
+                    message: expect.objectContaining({
+                        attachment: expect.objectContaining({ type: 'video' }),
+                    }),
+                })
+            )
         })
 
         it('should send audio when mime type is audio', async () => {
@@ -397,6 +405,14 @@ describe('InstagramProvider', () => {
             const result = await provider.sendMedia('user123', '', 'https://example.com/audio.mp3')
 
             expect(result).toEqual({ message_id: 'msg_123' })
+            expect(axios.post).toHaveBeenLastCalledWith(
+                expect.stringContaining('/messages'),
+                expect.objectContaining({
+                    message: expect.objectContaining({
+                        attachment: expect.objectContaining({ type: 'audio' }),
+                    }),
+                })
+            )
         })
 
         it('should warn and return when file type is not supported', async () => {

--- a/packages/provider-instagram/src/instagram.events.ts
+++ b/packages/provider-instagram/src/instagram.events.ts
@@ -90,9 +90,13 @@ export class InstagramEvents extends EventEmitterClass<ProviderEventTypes> {
         if (!messagingEvent.message) return
 
         const isEcho = messagingEvent.message?.is_echo || messagingEvent.message?.is_self
-        if (isEcho) return
+        if (isEcho) {
+            this.handleEcho(messagingEvent)
+            return
+        }
 
-        const sendObj = {
+        const attachment = messagingEvent.message?.attachments?.[0]
+        const sendObj: Record<string, any> = {
             body: messagingEvent.message?.text || '',
             from: messagingEvent.sender.id,
             name: '',
@@ -104,8 +108,7 @@ export class InstagramEvents extends EventEmitterClass<ProviderEventTypes> {
             messageId: messagingEvent.message?.mid || '',
         }
 
-        if (messagingEvent.message?.attachments && messagingEvent.message.attachments.length > 0) {
-            const attachment = messagingEvent.message.attachments[0]
+        if (attachment) {
             switch (attachment.type) {
                 case 'image':
                     sendObj.body = utils.generateRefProvider('_event_media_')
@@ -120,9 +123,47 @@ export class InstagramEvents extends EventEmitterClass<ProviderEventTypes> {
                     sendObj.body = utils.generateRefProvider('_event_document_')
                     break
             }
+            sendObj.data = { media: { url: attachment.payload?.url || '' } }
         }
 
-        this.emit('message', sendObj)
+        this.emit('message', sendObj as any)
+    }
+
+    private handleEcho = (messagingEvent: NonNullable<InstagramMessage['entry'][0]['messaging']>[0]) => {
+        if (!messagingEvent.message) return
+
+        const attachment = messagingEvent.message?.attachments?.[0]
+        let body = messagingEvent.message?.text || ''
+
+        if (attachment) {
+            switch (attachment.type) {
+                case 'image':
+                case 'video':
+                    body = utils.generateRefProvider('_event_media_')
+                    break
+                case 'audio':
+                    body = utils.generateRefProvider('_event_voice_note_')
+                    break
+                case 'file':
+                    body = utils.generateRefProvider('_event_document_')
+                    break
+            }
+        }
+
+        const sendObj: Record<string, any> = {
+            body,
+            from: messagingEvent.recipient.id,
+            name: '',
+            fromMe: true,
+            timestamp: messagingEvent.timestamp,
+            messageId: messagingEvent.message?.mid || '',
+        }
+
+        if (attachment) {
+            sendObj.data = { media: { url: attachment.payload?.url || '' } }
+        }
+
+        this.emit('host', sendObj)
     }
 
     private handlePostback = (messagingEvent: NonNullable<InstagramMessage['entry'][0]['messaging']>[0]) => {

--- a/packages/provider-instagram/src/instagram.provider.ts
+++ b/packages/provider-instagram/src/instagram.provider.ts
@@ -333,14 +333,14 @@ class InstagramProvider extends ProviderClass<InstagramEvents> {
      * @param attachmentId - The attachment_id from uploadAttachment
      * @returns Promise with the API response
      */
-    private sendAttachmentById = async (userId: string, attachmentId: string): Promise<any> => {
+    private sendAttachmentById = async (userId: string, attachmentId: string, type: 'image' | 'video' | 'audio'): Promise<any> => {
         const url = `${INSTAGRAM_API_URL}${this.globalVendorArgs.version}/${this.globalVendorArgs.igAccountId}/messages`
         try {
             const body = {
                 recipient: { id: userId },
                 message: {
                     attachment: {
-                        type: 'image',
+                        type,
                         payload: {
                             attachment_id: attachmentId,
                         },
@@ -372,7 +372,7 @@ class InstagramProvider extends ProviderClass<InstagramEvents> {
      */
     sendImageFromFile = async (userId: string, filePath: string): Promise<any> => {
         const attachmentId = await this.uploadAttachment(filePath, 'image')
-        return this.sendAttachmentById(userId, attachmentId)
+        return this.sendAttachmentById(userId, attachmentId, 'image')
     }
 
     /**
@@ -383,7 +383,7 @@ class InstagramProvider extends ProviderClass<InstagramEvents> {
      */
     sendVideoFromFile = async (userId: string, filePath: string): Promise<any> => {
         const attachmentId = await this.uploadAttachment(filePath, 'video')
-        return this.sendAttachmentById(userId, attachmentId)
+        return this.sendAttachmentById(userId, attachmentId, 'video')
     }
 
     /**
@@ -394,7 +394,7 @@ class InstagramProvider extends ProviderClass<InstagramEvents> {
      */
     sendAudioFromFile = async (userId: string, filePath: string): Promise<any> => {
         const attachmentId = await this.uploadAttachment(filePath, 'audio')
-        return this.sendAttachmentById(userId, attachmentId)
+        return this.sendAttachmentById(userId, attachmentId, 'audio')
     }
 
     /**


### PR DESCRIPTION
  video and audio sends

# Que tipo de Pull Request es?

- [ ] Mejoras
- [X ] Bug
- [ ] Docs / tests

Título: fix(provider-instagram): pass correct attachment type for video and
  audio sends

  ## Descripción

  los envíos de video y audio fallaran en la API de Instagram.

  **Root cause:** al subir el attachment con `uploadAttachment(filePath,
  'video')`
  el tipo se perdía al llamar a `sendAttachmentById`, que siempre enviaba
  `type: 'image'` en el payload.
  
  `type: 'image'` en el payload.

  **Fix:** `sendAttachmentById` ahora recibe el `type` como parámetro y lo
  pasa correctamente. Los callers `sendImageFromFile`, `sendVideoFromFile` y
  `sendAudioFromFile` pasan su tipo correspondiente.

  También se agrega manejo de echo messages con media en `instagram.events.ts`
  y se propaga la URL del media en `sendObj.data`.
> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
