### PR TITLE
feat: ensure bsuid is included and add tracking fields

### DIFF
--- a/packages/bot/src/core/coreClass.ts
+++ b/packages/bot/src/core/coreClass.ts
@@ -142,7 +142,7 @@ class CoreClass<P extends ProviderClass = any, D extends MemoryDB = any> extends
     handleMsg = async (messageCtxInComing: MessageContextIncoming) => {
         logger.log(`[handleMsg]: `, messageCtxInComing)
         idleForCallback.stop(messageCtxInComing)
-        const { body, from } = messageCtxInComing
+        const { body, from, source_id, source_type, ctwa_id } = messageCtxInComing
         let msgToSend = []
         let endFlowFlag = this.stateHandler.get(from)('__end_flow__') || false
         const fallBackFlag = false
@@ -159,6 +159,9 @@ class CoreClass<P extends ProviderClass = any, D extends MemoryDB = any> extends
                 body,
                 from,
                 prevRef: prevMsg.refSerialize,
+                source_id,
+                source_type,
+                ctwa_id,
             })
             await this.database.save(ctxByNumber)
         }
@@ -207,6 +210,9 @@ class CoreClass<P extends ProviderClass = any, D extends MemoryDB = any> extends
                 keyword,
                 index,
                 options: { media, buttons, capture, delay },
+                source_id,
+                source_type,
+                ctwa_id,
             })
         }
 

--- a/packages/bot/src/io/methods/toCtx.ts
+++ b/packages/bot/src/io/methods/toCtx.ts
@@ -10,13 +10,26 @@ interface ToCtxParams {
     keyword?: string
     options?: Options
     index?: number
+    source_id?: string
+    source_type?: string
+    ctwa_id?: string
 }
 
 /**
  * @param params ToCtxParams
  * @returns Context
  */
-const toCtx = ({ body, from, prevRef, keyword, options = {}, index }: ToCtxParams): TContext => {
+const toCtx = ({
+    body,
+    from,
+    prevRef,
+    keyword,
+    options = {},
+    index,
+    source_id,
+    source_type,
+    ctwa_id,
+}: ToCtxParams): TContext => {
     return {
         ref: generateRef(),
         keyword: prevRef ?? keyword,
@@ -24,6 +37,9 @@ const toCtx = ({ body, from, prevRef, keyword, options = {}, index }: ToCtxParam
         options: options,
         from,
         refSerialize: generateRefSerialize({ index, answer: body }),
+        source_id,
+        source_type,
+        ctwa_id,
     }
 }
 

--- a/packages/bot/src/types.ts
+++ b/packages/bot/src/types.ts
@@ -96,6 +96,9 @@ export type MessageContextIncoming = {
     ref?: string
     body?: string
     host?: string
+    source_id?: string
+    source_type?: string
+    ctwa_id?: string
 }
 
 /**
@@ -224,6 +227,9 @@ export interface TContext {
     keyword: string | string[]
     from?: string
     answer?: string | string[]
+    source_id?: string
+    source_type?: string
+    ctwa_id?: string
     refSerialize?: string
     endFlow?: boolean
     options: TCTXoptions

--- a/packages/provider-facebook-messenger/src/facebook.events.ts
+++ b/packages/provider-facebook-messenger/src/facebook.events.ts
@@ -62,10 +62,19 @@ export class MessengerEvents extends EventEmitterClass<ProviderEventTypes> {
             },
             timestamp: messagingEvent.timestamp,
             messageId: messagingEvent.message?.mid || '',
+        } as {
+            body: string
+            from: string
+            name: string
+            host: { id: string; phone: string }
+            timestamp: number
+            messageId: string
+            data?: { media: { url: string } }
         }
 
         if (messagingEvent.message?.attachments && messagingEvent.message.attachments.length > 0) {
             const attachment = messagingEvent.message.attachments[0]
+            sendObj.data = { media: { url: attachment.payload.url } }
             switch (attachment.type) {
                 case 'image':
                     sendObj.body = utils.generateRefProvider('_event_media_')

--- a/packages/provider-instagram/src/instagram.events.ts
+++ b/packages/provider-instagram/src/instagram.events.ts
@@ -102,10 +102,19 @@ export class InstagramEvents extends EventEmitterClass<ProviderEventTypes> {
             },
             timestamp: messagingEvent.timestamp,
             messageId: messagingEvent.message?.mid || '',
+        } as {
+            body: string
+            from: string
+            name: string
+            host: { id: string; phone: string }
+            timestamp: number
+            messageId: string
+            data?: { media: { url: string } }
         }
 
         if (messagingEvent.message?.attachments && messagingEvent.message.attachments.length > 0) {
             const attachment = messagingEvent.message.attachments[0]
+            sendObj.data = { media: { url: attachment.payload.url } }
             switch (attachment.type) {
                 case 'image':
                     sendObj.body = utils.generateRefProvider('_event_media_')

--- a/packages/provider-meta/src/types.ts
+++ b/packages/provider-meta/src/types.ts
@@ -113,6 +113,9 @@ export interface Message {
     id?: string
     caption?: string
     fromMe?: boolean
+    source_type?: string
+    source_id?: string
+    ctwa_id?: string
 }
 
 export interface ParamsIncomingMessage {

--- a/packages/provider-meta/src/utils/processIncomingMsg.ts
+++ b/packages/provider-meta/src/utils/processIncomingMsg.ts
@@ -21,11 +21,14 @@ export const processIncomingMessage = async ({
         case 'text': {
             responseObj = {
                 type: message.type,
-                from: message.from,
+                from: message.from || message.from_user_id,
                 to,
                 body: message.text?.body,
                 name: pushName,
                 pushName,
+                source_id: message?.referral?.source_id,
+                source_type: message?.referral?.source_type,
+                ctwa_id: message?.referral?.ctwa_clid,
             }
             break
         }
@@ -51,7 +54,7 @@ export const processIncomingMessage = async ({
         case 'button': {
             responseObj = {
                 type: 'button',
-                from: message.from,
+                from: message.from || message.from_user_id,
                 to,
                 body: message.button?.text,
                 payload: message.button?.payload,
@@ -65,7 +68,7 @@ export const processIncomingMessage = async ({
             const imageUrl = await getMediaUrl(version, message.image?.id, numberId, jwtToken)
             responseObj = {
                 type: message.type,
-                from: message.from,
+                from: message.from || message.from_user_id,
                 url: imageUrl ?? fileData?.url,
                 fileData,
                 caption: message?.image?.caption,
@@ -80,7 +83,7 @@ export const processIncomingMessage = async ({
             const documentUrl = await getMediaUrl(version, message.document?.id, numberId, jwtToken)
             responseObj = {
                 type: message.type,
-                from: message.from,
+                from: message.from || message.from_user_id,
                 url: documentUrl ?? fileData?.url,
                 fileData,
                 to,
@@ -94,7 +97,7 @@ export const processIncomingMessage = async ({
             const videoUrl = await getMediaUrl(version, message.video?.id, numberId, jwtToken)
             responseObj = {
                 type: message.type,
-                from: message.from,
+                from: message.from || message.from_user_id,
                 url: videoUrl ?? fileData?.url,
                 fileData,
                 caption: message?.video?.caption,
@@ -108,7 +111,7 @@ export const processIncomingMessage = async ({
         case 'location': {
             responseObj = {
                 type: message.type,
-                from: message.from,
+                from: message.from || message.from_user_id,
                 to,
                 latitude: message.location.latitude,
                 longitude: message.location.longitude,
@@ -122,7 +125,7 @@ export const processIncomingMessage = async ({
             const audioUrl = await getMediaUrl(version, message.audio?.id, numberId, jwtToken)
             responseObj = {
                 type: message.type,
-                from: message.from,
+                from: message.from || message.from_user_id,
                 url: audioUrl ?? fileData?.url,
                 fileData,
                 to,
@@ -136,7 +139,7 @@ export const processIncomingMessage = async ({
             const stickerUrl = await getMediaUrl(version, message.sticker?.id, numberId, jwtToken)
             responseObj = {
                 type: message.type,
-                from: message.from,
+                from: message.from || message.from_user_id,
                 url: stickerUrl ?? fileData?.url,
                 fileData,
                 to,
@@ -150,7 +153,7 @@ export const processIncomingMessage = async ({
         case 'contacts': {
             responseObj = {
                 type: message.type,
-                from: message.from,
+                from: message.from || message.from_user_id,
                 contacts: [
                     {
                         name: message.contacts[0].name,
@@ -167,7 +170,7 @@ export const processIncomingMessage = async ({
         case 'order': {
             responseObj = {
                 type: message.type,
-                from: message.from,
+                from: message.from || message.from_user_id,
                 to,
                 order: {
                     catalog_id: message.order.catalog_id,


### PR DESCRIPTION
Ensure the BSUID is implicitly included in the Meta provider lifecycle when it is missing from the incoming payload, and extend the provider context structure to capture new tracking properties from Click-to-WhatsApp ads, specifically mapping source_id and ctwa_clid (ads click ID) to support granular referral attribution.

# Que tipo de Pull Request es?

- [X ] Mejoras
- [ ] Bug
- [ ] Docs / tests
