### PR TITLE
fix(provider-gohighlevel): parse attachments as plain URL strings

### DIFF
--- a/packages/provider-gohighlevel/__tests__/utils.test.ts
+++ b/packages/provider-gohighlevel/__tests__/utils.test.ts
@@ -140,6 +140,26 @@ describe('#processIncomingMessage', () => {
         expect(result!.type).toBe('audio')
     })
 
+    test('should process inbound audio message when attachments is a plain URL string array (real GHL webhook shape)', () => {
+        const webhook: GHLIncomingWebhook = {
+            type: 'InboundMessage',
+            locationId: 'loc_123',
+            direction: 'inbound',
+            body: '',
+            phone: '+1234567890',
+            contactId: 'contact_123',
+            messageId: 'msg_audio_string',
+            attachments: ['https://example.com/voice-note.mp3'],
+        }
+
+        const result = processIncomingMessage(webhook)
+
+        expect(result).not.toBeNull()
+        expect(result!.type).toBe('audio')
+        expect(result!.url).toBe('https://example.com/voice-note.mp3')
+        expect(result!.attachments).toEqual([{ url: 'https://example.com/voice-note.mp3' }])
+    })
+
     test('should process inbound message with document attachment', () => {
         const webhook: GHLIncomingWebhook = {
             type: 'InboundMessage',

--- a/packages/provider-gohighlevel/src/types.ts
+++ b/packages/provider-gohighlevel/src/types.ts
@@ -93,7 +93,8 @@ export interface GHLIncomingWebhook {
     email?: string
     direction?: 'inbound' | 'outbound'
     status?: string
-    attachments?: GHLAttachment[]
+    /** GHL sends this as an array of plain URL strings for InboundMessage webhooks */
+    attachments?: (GHLAttachment | string)[]
     dateAdded?: string
     [key: string]: any
 }

--- a/packages/provider-gohighlevel/src/utils/processIncomingMsg.ts
+++ b/packages/provider-gohighlevel/src/utils/processIncomingMsg.ts
@@ -1,8 +1,29 @@
 import { utils } from '@builderbot/bot'
+import mime from 'mime-types'
 
 import { parseGHLNumber } from './number'
 
-import type { GHLMessage, GHLIncomingWebhook } from '~/types'
+import type { GHLAttachment, GHLMessage, GHLIncomingWebhook } from '~/types'
+
+/**
+ * GHL's InboundMessage webhook sends `attachments` as an array of plain URL
+ * strings (not `{ url, type }` objects). Normalize both shapes so downstream
+ * code can always read `.url` / `.type`.
+ */
+const normalizeAttachments = (raw: GHLIncomingWebhook['attachments']): GHLAttachment[] => {
+    if (!raw) return []
+    return raw.map((att) => (typeof att === 'string' ? { url: att } : att))
+}
+
+/**
+ * Resolves the attachment's mime type, falling back to guessing from the
+ * URL's file extension when GHL doesn't include a `type` field.
+ */
+const resolveAttachmentType = (attachment: GHLAttachment): string => {
+    if (attachment.type) return attachment.type.toLowerCase()
+    const guessed = mime.lookup(attachment.url.split('?')[0])
+    return guessed ? guessed.toLowerCase() : ''
+}
 
 export const processIncomingMessage = (webhook: GHLIncomingWebhook): GHLMessage | null => {
     if (!webhook || webhook.direction !== 'inbound') return null
@@ -12,22 +33,16 @@ export const processIncomingMessage = (webhook: GHLIncomingWebhook): GHLMessage 
     const from = webhook.contactId || phone || ''
     const name = webhook.contactId ?? phone
 
-    // Debug log
-    console.log('[GHL DEBUG] processIncomingMessage:', {
-        'webhook.phone': webhook.phone,
-        'webhook.contactId': webhook.contactId,
-        'parsed phone': phone,
-        'final from': from,
-    })
-    const hasAttachments = webhook.attachments && webhook.attachments.length > 0
+    const attachments = normalizeAttachments(webhook.attachments)
+    const hasAttachments = attachments.length > 0
 
     let body = webhook.body ?? ''
     let type = 'text'
     let url: string | undefined
 
     if (hasAttachments) {
-        const attachment = webhook.attachments[0]
-        const attachmentType = attachment.type?.toLowerCase() ?? ''
+        const attachment = attachments[0]
+        const attachmentType = resolveAttachmentType(attachment)
 
         if (attachmentType.includes('image')) {
             type = 'image'
@@ -66,7 +81,7 @@ export const processIncomingMessage = (webhook: GHLIncomingWebhook): GHLMessage 
     }
 
     if (url) message.url = url
-    if (hasAttachments) message.attachments = webhook.attachments
+    if (hasAttachments) message.attachments = attachments
 
     return message
 }


### PR DESCRIPTION
GHL's InboundMessage webhook sends `attachments` as an array of plain URL strings, not `{url, type}` objects as the code assumed. This caused every attachment (audio, image, video) to be misclassified as `document` with no `url`, so incoming voice notes never matched EVENTS.VOICE_NOTE and bots never responded to audio messages.

Normalize both shapes and infer the mime type from the URL extension when GHL doesn't send a `type` field.

# Que tipo de Pull Request es?

- [ ] Mejoras
- [x] Bug
- [ ] Docs / tests

# Descripción

Por favor agrega una descripción de tu aporte para tener más contexto y poder avanzar más rápido. Si es de ayuda puedes usar plataformar como [https://www.loom.com/](https://www.loom.com/) para grabar un video.


> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
