### PR TITLE
fix(eslint-plugin-builderbot): replace removed context.getAncestors

### DIFF
--- a/packages/eslint-plugin-builderbot/__tests__/processEndFlowWithFlowDynamic.test.ts
+++ b/packages/eslint-plugin-builderbot/__tests__/processEndFlowWithFlowDynamic.test.ts
@@ -1,7 +1,9 @@
+import { Linter } from 'eslint'
 import sinon from 'sinon'
 import { test } from 'uvu'
 import * as assert from 'uvu/assert'
 
+import { rules } from '../src'
 import { processEndFlowWithFlowDynamic } from '../src/rules'
 
 test('processStateUpdateAwait should not report if "state.update" is not accessed', () => {
@@ -38,7 +40,7 @@ test('Debería llamar a context.report con el mensaje correcto si se detecta end
     const reportStub = sinon.stub()
 
     const contextMock: any = {
-        getAncestors: getAncestorsStub,
+        sourceCode: { getAncestors: getAncestorsStub },
         report: reportStub,
     }
 
@@ -62,6 +64,35 @@ test('Debería llamar a context.report con el mensaje correcto si se detecta end
     assert.ok(reportStub.called)
     assert.is(reportStub.firstCall.args[0].node, mockNode)
     assert.is(reportStub.firstCall.args[0].message, 'Do not use endFlow in the same execution context as flowDynamic.')
+})
+
+const lintWithRule = (code: string) =>
+    new Linter().verify(code, {
+        plugins: { builderbot: { rules } },
+        rules: { 'builderbot/func-prefix-endflow-flowdynamic': 'error' },
+    } as any)
+
+test('Debería reportar endFlow junto a flowDynamic al ejecutarse sobre ESLint 9 (issue #1241)', () => {
+    const messages = lintWithRule(
+        [
+            "addKeyword('hi').addAction(async (ctx, { flowDynamic, endFlow }) => {",
+            "    await flowDynamic('one message')",
+            "    return endFlow('bye')",
+            '})',
+        ].join('\n')
+    )
+
+    assert.is(messages.length, 1)
+    assert.is(messages[0].ruleId, 'builderbot/func-prefix-endflow-flowdynamic')
+    assert.is(messages[0].message, 'Do not use endFlow in the same execution context as flowDynamic.')
+})
+
+test('No debería reportar endFlow cuando no hay flowDynamic en el mismo contexto (ESLint 9)', () => {
+    const messages = lintWithRule(
+        ["addKeyword('hi').addAction(async (ctx, { endFlow }) => {", "    return endFlow('bye')", '})'].join('\n')
+    )
+
+    assert.is(messages.length, 0)
 })
 
 test.run()

--- a/packages/eslint-plugin-builderbot/src/rules/processEndFlowWithFlowDynamic.ts
+++ b/packages/eslint-plugin-builderbot/src/rules/processEndFlowWithFlowDynamic.ts
@@ -1,15 +1,15 @@
-import type { INode, Context } from '../types'
+import type { INode, SourceCodeContext } from '../types'
 import { isInsideAddActionOrAddAnswer } from '../utils'
 
-const processEndFlowWithFlowDynamic = (context: Context) => {
+const processEndFlowWithFlowDynamic = (context: SourceCodeContext) => {
     return {
         'CallExpression[callee.name="endFlow"]'(node: INode) {
             if (!isInsideAddActionOrAddAnswer(node)) {
                 return
             }
 
-            const blockStatement = context
-                .getAncestors()
+            const blockStatement = context.sourceCode
+                .getAncestors(node)
                 .find((ancestor: { type: string }) => ancestor.type === 'BlockStatement')
             if (blockStatement) {
                 const calleInsideCtx = blockStatement.body.map(

--- a/packages/eslint-plugin-builderbot/src/types.ts
+++ b/packages/eslint-plugin-builderbot/src/types.ts
@@ -27,6 +27,9 @@ export interface ReportOptions {
 }
 
 export interface Context {
-    getAncestors?: () => any
     report: (options: ReportOptions) => void
+}
+
+export interface SourceCodeContext extends Context {
+    sourceCode: { getAncestors: (node: INode) => any[] }
 }


### PR DESCRIPTION
Fixes #1241.

### The bug

`processEndFlowWithFlowDynamic` calls `context.getAncestors()`. That method was **removed** from the rule context in ESLint 9, so as soon as the rule visits an `endFlow()` call inside `addAction`/`addAnswer`, ESLint throws:

```
TypeError: context.getAncestors is not a function
Rule: builderbot/func-prefix-endflow-flowdynamic
```

That is exactly the scenario in #1241: scaffold a bot, paste the documented `endFlow` example, run `pnpm run lint`. The rule is part of `rulesRecommended`, so every ESLint 9 user of the recommended config hits it.

### The fix

One line: `context.getAncestors()` becomes `context.sourceCode.getAncestors(node)`, the documented ESLint 9 replacement. It returns the same `Program`-to-parent ancestor list, so the `BlockStatement` lookup and the reporting logic are unchanged.

I checked the rest of the package and this is the only use of a removed API. `processStateUpdateAwait`'s `context.getSourceCode()` is deprecated but still supported in ESLint 9 (I ran it to be sure), so I left it alone.

`types.ts` gains a `SourceCodeContext extends Context` rather than putting `sourceCode` on the shared `Context`, since only this one rule needs it and the other four rules' mocks are typed against `Context`.

### The tests

The existing test stubbed `context.getAncestors` with sinon, which is why it stayed green through the ESLint 9 bump. I updated it to the new shape and added two tests that run the real exported plugin through ESLint 9's `Linter`, so the rule is checked against the actual API instead of a mock.

Mutation-checked against the same suite:

- Unfixed `context.getAncestors()`: the new tests fail with `context.getAncestors is not a function`, raised by ESLint's own rule error handler.
- `sourceCode.getAncestors()` without the `node` argument: the new tests fail with `Missing required argument: node.` The sinon stub does **not** catch this one.
- Reporting unconditionally: the new no-report test fails.

No new dependency, and `pnpm-lock.yaml` is untouched. `eslint` is already a root devDependency, and the test imports it the same way every test file in this package already imports `uvu`.

### Verified locally

CI does not run on PRs targeting `builderbot` (the test job in `releases-dev.yml` only fires for `builderbot-dev`, which is currently 90 commits behind), so here is what I ran:

- `pnpm --filter eslint-plugin-builderbot test`: 22/22 pass (20 before this PR)
- `npx eslint` with the root flat config over `src` and `__tests__`: clean
- `npx prettier --check`: clean
- `pnpm --filter eslint-plugin-builderbot build`: builds, types check

### Two notes, both optional

`context.sourceCode` needs ESLint >= 8.40. The repo pins `eslint ^9.39.1` and the package declares no ESLint peer range, so I took the clean swap over a `context.sourceCode ?? context.getSourceCode()` branch. Happy to add the fallback if you want to keep ESLint 8.0 through 8.39 working.

Separately, and **not** part of this PR: ancestors come back root-first, so `.find(a => a.type === 'BlockStatement')` picks the *outermost* block rather than the enclosing one. Declare a flow inside a function and the rule silently stops reporting; I confirmed it against the built plugin. That behaves identically before and after this change, so I left it alone. Say the word and I will open a separate issue.

---

Disclosure: I used an AI assistant while working on this. I reproduced the crash, wrote and ran the tests and the mutation checks, and reviewed everything here myself.