### PR TITLE
fix(provider-meta): use list_reply title instead of id for interactiv…

### DIFF
--- a/packages/provider-meta/__tests__/processIncomingMessage.test.ts
+++ b/packages/provider-meta/__tests__/processIncomingMessage.test.ts
@@ -46,7 +46,7 @@ describe('#processIncomingMessage ', () => {
                 from: 'sender',
                 interactive: {
                     button_reply: { title: 'Button Reply' },
-                    list_reply: { id: 'List Reply' },
+                    list_reply: { id: 'row_id_1', title: 'List Reply' },
                 },
             },
             to: 'receiver',
@@ -58,13 +58,15 @@ describe('#processIncomingMessage ', () => {
         // Act
         const result = await processIncomingMessage(params)
 
-        // Assert
+        // Assert — button_reply takes priority over list_reply when both are present
         expect(result).toEqual({
             type: 'interactive',
             from: 'sender',
             to: 'receiver',
             body: 'Button Reply',
             title_button_reply: 'Button Reply',
+            title_list_reply: 'List Reply',
+            id_list_reply: 'row_id_1',
             pushName: 'John Doe',
             name: 'John Doe',
             message_id: '123',
@@ -81,8 +83,11 @@ describe('#processIncomingMessage ', () => {
             message: {
                 type: 'interactive',
                 from: 'sender',
+                // `id` is an internal row identifier (e.g. a random nanoid) unrelated to the
+                // user-visible option text — `body` must resolve to `title`, not `id`, so
+                // keyword/flow matching against the visible option text keeps working.
                 interactive: {
-                    list_reply: { id: 'List Reply' },
+                    list_reply: { id: 'row_id_2', title: 'List Reply' },
                 },
             },
             to: 'receiver',
@@ -101,7 +106,8 @@ describe('#processIncomingMessage ', () => {
             to: 'receiver',
             body: 'List Reply',
             title_button_reply: undefined,
-            title_list_reply: undefined,
+            title_list_reply: 'List Reply',
+            id_list_reply: 'row_id_2',
             pushName: 'John Doe',
             nfm_reply: undefined,
             name: 'John Doe',

--- a/packages/provider-meta/src/types.ts
+++ b/packages/provider-meta/src/types.ts
@@ -173,6 +173,7 @@ export interface Message {
     payload?: string
     title_button_reply?: string
     title_list_reply?: string
+    id_list_reply?: string
     latitude?: number
     longitude?: number
     contacts?: Contact[]

--- a/packages/provider-meta/src/utils/processIncomingMsg.ts
+++ b/packages/provider-meta/src/utils/processIncomingMsg.ts
@@ -41,10 +41,11 @@ export const processIncomingMessage = async ({
                 to,
                 body:
                     message.interactive?.button_reply?.title ??
-                    message.interactive?.list_reply?.id ??
-                    message.interactive?.nfm_reply.response_json,
+                    message.interactive?.list_reply?.title ??
+                    message.interactive?.nfm_reply?.response_json,
                 title_button_reply: message.interactive?.button_reply?.title,
                 title_list_reply: message.interactive?.list_reply?.title,
+                id_list_reply: message.interactive?.list_reply?.id,
                 nfm_reply: message.interactive?.nfm_reply?.response_json
                     ? JSON.parse(message.interactive?.nfm_reply?.response_json)
                     : undefined,


### PR DESCRIPTION
…e body

Meta's `list_reply.id` is an internal row identifier (in BuilderBot Cloud's flow builder, a random nanoid) unrelated to the option's visible text. Using it as `body` meant list-based interactive replies never matched the keywords/flow rules users define against the option's title, while button replies (which already used `button_reply.title`) worked fine.

- body now resolves to `list_reply.title`, consistent with `button_reply`
- add `id_list_reply` so the original row id is still accessible
- fix missing optional chaining on `nfm_reply.response_json`
- update tests to cover distinct id/title values


Claude-Session: https://claude.ai/code/session_017r24dxpUWwP1YQCNbxgAFB

# Que tipo de Pull Request es?

- [ ] Mejoras
- [ ] Bug
- [ ] Docs / tests

# Descripción

Por favor agrega una descripción de tu aporte para tener más contexto y poder avanzar más rápido. Si es de ayuda puedes usar plataformar como [https://www.loom.com/](https://www.loom.com/) para grabar un video.


> Forma parte de este proyecto.

-   [Discord](https://link.codigoencasa.com/DISCORD)
-   [𝕏 (Twitter)](https://twitter.com/leifermendez)
-   [Youtube](https://www.youtube.com/watch?v=5lEMCeWEJ8o&list=PL_WGMLcL4jzWPhdhcUyhbFU6bC0oJd2BR)
-   [Telegram](https://t.me/leifermendez)
